### PR TITLE
Fix code block style in old blog post (fixes mdl MD046 error)

### DIFF
--- a/_posts/blog/2014-10-31-research_update1.md
+++ b/_posts/blog/2014-10-31-research_update1.md
@@ -28,12 +28,13 @@ Using the New York Cogent site as an indicator, at the beginning of February 201
 
 Below we show an example of the ToS field in the IP header of packets received from a Verizon FIOS customers on February 28, 2014 from the data we extracted. Those wishing to explore this more fully are welcome to access the NDT data archives from [BigStore](https://console.developers.google.com/storage/m-lab/ndt/). Each M-Lab site should have an extensive sample of ndttrace files.
 
-{:.no-highlight}
+```text
     16:21:09.973746 IP (tos 0x48, ttl 55, id 23787, offset 0, flags [DF], proto TCP (6), length 1500)
         pool-108-41-239-212.nycmny.fios.verizon.net.57090 > 38.106.70.160.40047: Flags [P.], seq 3337041:3338489, ack 0, win 8235, options [nop, nop,TS[|tcp]>
              0x0000:  4548 05dc 5ceb 4000 3706 17e1 6c29 efd4  EH..\.@.7...l)..
              0x0010:  266a 46a0 df02 9c6f 241b 4941 fb8f 03bf  &jF....o$.IA....
              0x0020:  8018 202b f194 0000 0101 080a            ...+........
+```
 
 ![Example of ToS field in the IP header of packets received from a Verizon FIOS customers on February 28, 2014 from the data we extracted]({{ site.baseurl }}/images/blog/blog1-image2.png){:.inherit-width width="100%"}<br />
 What does this indicate? It indicates that the recovery from the degradation in performance observed prior to February 2014 may not have been experienced by all consumers.


### PR DESCRIPTION
Hi, M-Lab folks. First-time contributor here.

The formatting in one of the old blog posts is not passing your `mdl` checks. For me, when configuring the repo with your Git hooks as recommended [in your CONTRIBUTING file](https://github.com/m-lab/m-lab.github.io/blob/d6844d2c3efd52e1b74fa9fe554f2def8d7368e7/CONTRIBUTING.md#setting-up-local-development-environment), it causes new commits to be aborted.

```
[~/local/repos/m-lab.github.io]
$ git commit -a -m 'Typo and style fixes'
_posts/blog/2014-10-31-research_update1.md:32: MD046 Code block style

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
[2018-12-19T16:15:59-0500]: COMMIT ABORTED! Please address the errors before committing.
```

This PR modifies that blog post to pass the `mdl` checks and pass the pre-commit hook check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/429)
<!-- Reviewable:end -->
