### PR TITLE
Use `bundle exec` with `jekyll serve` in local dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ ln -s -f ../_hooks hooks
 * From within the cloned website repository, install required dependencies:
   * `bundle install`
 * Test a working installation by running the Jekyll server, passing in a blank `--baseurl` parameter:
-  * `jekyll serve --baseurl`
+  * `bundle exec jekyll serve --baseurl`
   * View the generated site by going to [http://localhost:4000/](http://localhost:4000/)
 
 ## Code Standards and Practice


### PR DESCRIPTION
Since you're using Bundler to install gems in your local dev environment setup, I think you need to use `bundle exec` with the `jekyll serve` command.

For example:

I just set up a fresh dev environment following [the instructions in CONTRIBUTING](https://github.com/m-lab/m-lab.github.io/blob/d6844d2c3efd52e1b74fa9fe554f2def8d7368e7/CONTRIBUTING.md#setting-up-local-development-environment).

Plain `jekyll serve` fails due to a Gem version mismatch:

```
[~/local/repos/m-lab.github.io]
$ jekyll serve
Traceback (most recent call last):
	10: from /Users/janke/bin/jekyll:23:in `<main>'
	 9: from /Users/janke/bin/jekyll:23:in `load'
	 8: from /usr/local/lib/ruby/gems/2.5.0/gems/jekyll-3.8.5/exe/jekyll:11:in `<top (required)>'
	 7: from /usr/local/lib/ruby/gems/2.5.0/gems/jekyll-3.8.5/lib/jekyll/plugin_manager.rb:50:in `require_from_bundler'
	 6: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler.rb:107:in `setup'
	 5: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:26:in `setup'
	 4: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:26:in `map'
	 3: from /usr/local/Cellar/ruby/2.5.3_1/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	 2: from /usr/local/Cellar/ruby/2.5.3_1/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	 1: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:31:in `block in setup'
/usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:319:in `check_for_activated_spec!': You have already activated jekyll-sass-converter 1.5.2, but your Gemfile requires jekyll-sass-converter 1.5.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```

Adding `bundle exec` fixes it:

```
[~/local/repos/m-lab.github.io]
$ bundle exec jekyll serve
Configuration file: /Users/janke/local/repos/m-lab.github.io/_config.yml
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
            Source: /Users/janke/local/repos/m-lab.github.io
       Destination: /Users/janke/local/repos/m-lab.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
  Conversion error: JekyllJupyterNotebook::Converter encountered an error while converting 'notebooks/discard-analysis-2018.ipynb':
                    No such file or directory - jupyter
jekyll 3.6.2 | Error:  No such file or directory - jupyter
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/431)
<!-- Reviewable:end -->
