### PR TITLE
Jekyll config: update "gems" option to "plugins".

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ kramdown:
 future: true
 
 # Gems
-gems: ['jekyll-paginate', 'jekyll-feed', 'jekyll-jupyter-notebook']
+plugins: ['jekyll-paginate', 'jekyll-feed', 'jekyll-jupyter-notebook']
 paginate: 5
 paginate_path: "/blog/page/:num"
 


### PR DESCRIPTION
In Jekyll 3.5, the "gems" option was renamed to "plugins". This PR updates the config file to use the new option name.

Fixes this deprecation warning "Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.".

```
$ bundle exec jekyll serve
Configuration file: /Users/janke/local/repos/m-lab.github.io/_config.yml
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
            Source: /Users/janke/local/repos/m-lab.github.io
```

References:
* https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/
* https://github.com/jekyll/jekyll-sitemap/issues/181

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/432)
<!-- Reviewable:end -->
