### PR TITLE
Local dev env: add explicit empty string arg to --baseurl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ ln -s -f ../_hooks hooks
 * From within the cloned website repository, install required dependencies:
   * `bundle install`
 * Test a working installation by running the Jekyll server, passing in a blank `--baseurl` parameter:
-  * `jekyll serve --baseurl`
+  * `jekyll serve --baseurl ""`
   * View the generated site by going to [http://localhost:4000/](http://localhost:4000/)
 
 ## Code Standards and Practice


### PR DESCRIPTION
In the "local dev environment" part of CONTRIBUTING:

I think you need to pass an empty string as the argument to `jekyll serve --baseurl`, not just omit the argument.

Using the current instructions:

```
$ bundle exec jekyll serve --baseurl
bundler: failed to load command: jekyll (/usr/local/lib/ruby/gems/2.5.0/bin/jekyll)
OptionParser::MissingArgument: missing argument: --baseurl
  /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:31:in `go'
  /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  /usr/local/lib/ruby/gems/2.5.0/gems/jekyll-3.6.2/exe/jekyll:15:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.5.0/bin/jekyll:23:in `load'
  /usr/local/lib/ruby/gems/2.5.0/bin/jekyll:23:in `<top (required)>'
```

Using an explicit `""` argument:

```
$ bundle exec jekyll serve --baseurl ""
Configuration file: /Users/janke/local/repos/m-lab.github.io/_config.yml
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
            Source: /Users/janke/local/repos/m-lab.github.io
       Destination: /Users/janke/local/repos/m-lab.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/433)
<!-- Reviewable:end -->
