### PR TITLE
CONTRIBUTING: Add additional dependencies to setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,13 @@ ln -s -f ../_hooks hooks
 ```
 
 * [Install Jekyll](https://jekyllrb.com/docs/installation/) using the instruc tions appropriate for your operating system
+* [Install Jupyter](https://jupyter.org/install)
+  * `pip install jupyter` might well work
+* [Install Bundler](https://bundler.io/)
+  * `gem install bundler` might well work
+* [Install markdownlint](https://github.com/markdownlint/markdownlint)
+  * `gem install mdl` might well work
+* [Install Node.js](https://nodejs.org/en/download/)
 * From within the cloned website repository, install required dependencies:
   * `bundle install`
 * Test a working installation by running the Jekyll server, passing in a blank `--baseurl` parameter:


### PR DESCRIPTION
Fixes #430.

Running the website locally requires Bundler, Jupyter, and doing the pre-commit checks requires markdownlint and Node.js, but they're not included in the local dev environment setup instructions. This PR adds them.

An alternative to listing markdownlint might be to replace the plain `mdl` command in _tests/travis-checks with `bundle exec mdl`. (https://github.com/m-lab/m-lab.github.io/pull/443 does this.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/440)
<!-- Reviewable:end -->
