### PR TITLE
Forbid non-HTTPS www.measurementlab.net URLs

### DIFF
--- a/_linter/markdown-linter-rules.rb
+++ b/_linter/markdown-linter-rules.rb
@@ -1,0 +1,22 @@
+# Custom linter rules for M-Lab
+#
+# These rule names use the prefix "ML" for "Measurement Lab"
+#  ----------------------------------------------------------------------------
+
+
+rule "ML001", "Forbid non-HTTPS www.measurementlab.net links" do
+  aliases "forbid-non-HTTPS-links"
+  check do |doc|
+    lines = doc.lines
+    bad_lines = []
+    i_line = 0
+    while i_line < lines.length
+      line = lines[i_line]
+      if line.match(%r{http://www\.measurementlab\.net}i)
+        bad_lines << i_line
+      end
+      i_line = i_line + 1      
+    end
+    bad_lines
+  end
+end

--- a/_linter/markdown-linter-style.rb
+++ b/_linter/markdown-linter-style.rb
@@ -47,3 +47,7 @@ exclude_rule 'MD036'
 
 ## MD041 First line in file should be a top level header
 exclude_rule 'MD041'
+
+#  Our custom linter rules
+#  ----------------------------------------------------------------------------
+rule 'ML001'

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -195,7 +195,7 @@ By becoming an M-Lab supporting partner, companies, nonprofit organizations, aca
 * By embedding an M-Lab client tool in an application or service, allowing M-Lab to reach more people and generate more data.
 * By providing direct financial support.
 
-If you'd like to get involved as an M-Lab supporting partner, [contact](http://www.measurementlab.net/contact) the M-Lab team and join the [M-Lab Discuss Group](https://groups.google.com/a/measurementlab.net/forum/#!forum/discuss).
+If you'd like to get involved as an M-Lab supporting partner, [contact](https://www.measurementlab.net/contact) the M-Lab team and join the [M-Lab Discuss Group](https://groups.google.com/a/measurementlab.net/forum/#!forum/discuss).
 
 ## How can researchers get involved?
 {:.no_toc}

--- a/_tests/travis-checks
+++ b/_tests/travis-checks
@@ -3,7 +3,7 @@
 set -e
 
 # Execute Markdown Linter
-mdl README.md _posts _pages --style _linter/markdown-linter-style.rb
+mdl README.md _posts _pages --style _linter/markdown-linter-style.rb --rules _linter/markdown-linter-rules.rb
 
 # Github Pages needs the baseurl field to be "m-lab.github.io" to render properly in forked 
 # repos, but when we deploy to production, we need the baseurl field to be empty. This 


### PR DESCRIPTION
Here's a custom markdownlint linter to forbid non-HTTPS links to `www.measurementlab.net`, as requested by #166.

Includes a fix for a bad link it caught.

Closes #166.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/441)
<!-- Reviewable:end -->
