### PR TITLE
add travis config for production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ deploy:
     condition: "$TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push"
 
 ## - production
-#- provider: script
-#  script:
-#    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-#    && gsutil cp -r $TRAVIS_BUILD_DIR/_site/* gs://website.mlab-oit.measurementlab.net/
-#  skip_cleanup: true
-#  on:
-#    repo: m-lab/website
-#    tags: true
+- provider: script
+  script:
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
+    && gsutil cp -r $TRAVIS_BUILD_DIR/_site/* gs://website.mlab-oti.measurementlab.net/
+  skip_cleanup: true
+  on:
+    repo: m-lab/website
+    tags: true


### PR DESCRIPTION
Building on #449, which added support for automated builds to push the site to a staging GCS bucket, this PR adds the configuration to build and push tagged releases to a GCS bucket in the production project, mlab-oti. A successful merge of this PR will build and push to the staging bucket first. Following that an operator will tag a new release, triggering a build and push to `gs://website.mlab-oti.measurementlab.net` which resolves to: https://website.mlab-oti.measurementlab.net/ 

Upon successful tagged release+build, a follow on PR in https://github.com/m-lab/dns-zones will redirect production site traffic from AWS to GCS.

@stephen-soltesz PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/450)
<!-- Reviewable:end -->
