### PR TITLE
simplify travis deploy to prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ deploy:
   on:
     repo: m-lab/website
     all_branches: true
-    condition: "$TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push"
+    condition: "$TRAVIS_BRANCH == master"
     tags: true


### PR DESCRIPTION
The last tagged release was not pushed to firebase, so this PR just removes the "push" directive for travis production builds when a release is tagged. Merging unreviewed in an effort to get current site updated to restore the ndt test page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/454)
<!-- Reviewable:end -->
