### PR TITLE
adjusted firebase redirect rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,4 @@ deploy:
   script: "firebase use mlab-oti && firebase deploy --only hosting --token $FIREBASE_TOKEN"
   on:
     repo: m-lab/website
-    all_branches: true
-    condition: "$TRAVIS_BRANCH == master"
     tags: true

--- a/firebase.json
+++ b/firebase.json
@@ -7,12 +7,12 @@
       "**/node_modules/**"
     ],
     "redirects": [ {
-      "source": "/data/bq/examples/",
-      "destination": "/data/docs/bq/examples/",
+      "source": "/data/bq/examples",
+      "destination": "/data/docs/bq/examples",
       "type": 301
 	}, {
-      "source": "/data/bq/quickstart/",
-      "destination": "/data/docs/bq/quickstart/",
+      "source": "/data/bq/quickstart",
+      "destination": "/data/docs/bq/quickstart",
       "type": 301
     }, {
   


### PR DESCRIPTION
Firebase expects blob patterns on redirect statements with a trailing slash. Removed trailing slashes on test redirects since these are individual uri 301s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/464)
<!-- Reviewable:end -->
