### PR TITLE
update ndt submodule to master, incorporate new ndt c2s fix

### DIFF
--- a/_pages/301-learn-glossary.md
+++ b/_pages/301-learn-glossary.md
@@ -3,5 +3,5 @@ layout: redirect
 permalink: /learn/glossary/
 title: "Glossary"
 page-title: "Glossary"
-redirect_to: "https://measurementlab.net/learn/definitions"
+redirect_to: "https://measurementlab.net/learn/"
 ---

--- a/_pages/301-learn-internet.md
+++ b/_pages/301-learn-internet.md
@@ -3,5 +3,5 @@ layout: redirect
 permalink: /learn/internet/
 title: "How the Internet Works"
 page-title: "How the Internet Works"
-redirect_to: "https://measurementlab.net/learn/m-lab-internet-topology/"
+redirect_to: "https://measurementlab.net/learn/"
 ---


### PR DESCRIPTION
This PR updates the NDT submodule to master, so the recent c2s fixes that were ported from `ndt-server`, addressing: #507 

We have recently removed the NDT test from the NDT page, but it can be viewed once published at https:/measurementlab.net/p/ndt-ws.html

For confirming this PR, we should confirm that this file has the right fixes in it:
* https://github.com/m-lab/website/blob/master/_layouts/ndt-test.html
from:
* https://github.com/m-lab/ndt/blob/master/HTML5-frontend/ndt-browser-client.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/510)
<!-- Reviewable:end -->
