### PR TITLE
Prevent BibTeX from turning Measurement Lab into Lab. Measurement

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -120,7 +120,7 @@ or, in [BibTeX](https://en.wikipedia.org/wiki/BibTeX){:target="_blank"} format:
 
 ```bibtex
 @misc{mlab,
-        author="Measurement Lab",
+        author="{Measurement Lab}",
         title="The {M}-{L}ab {NDT} Data Set",
         year="(2009-02-11 -- 2015-12-21)",
         howpublished="\url{https://measurementlab.net/tests/ndt}",

--- a/_pages/tests/ndt/ndt.md
+++ b/_pages/tests/ndt/ndt.md
@@ -40,7 +40,7 @@ or, in [BibTeX](https://en.wikipedia.org/wiki/BibTeX){:target="_blank"} format:
 
 ```bibtex
 @misc{mlab,
-        author="Measurement Lab",
+        author="{Measurement Lab}",
         title="The {M}-{L}ab {NDT} Data Set",
         year="(2009-02-11 -- 2015-12-21)",
         howpublished="\url{https://measurementlab.net/tests/ndt}",


### PR DESCRIPTION
Prevent BibTeX from turning "Measurement Lab" into "Lab, Measurement"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/516)
<!-- Reviewable:end -->
