### PR TITLE
Add first generated bigquery schema reference for ndt5 to website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
 - sudo apt-get install -y python3-pip
 - sudo python3 -m pip install --upgrade setuptools pip
 - sudo python3 -m pip install jupyter nbconvert
+- docker run -v $PWD:/workspace -w /workspace
+    -it measurementlab/generate-schema-docs:v0.1.0 -doc.output _includes
 - npm install -g firebase-tools
 - "./_tests/travis-checks --quick"
 

--- a/_pages/tests/ndt/ndt5.md
+++ b/_pages/tests/ndt/ndt5.md
@@ -17,4 +17,6 @@ More details about the ndt5 protocol can be found in the [README for ndt5 on Git
 
 ## ndt5 BigQuery "Faithful" Schema
 
-{% include schema_ndt5_faithful.html %}
+<div class="table-responsive" markdown="1">
+{% include schema_ndtresultrow.md %}
+</div>


### PR DESCRIPTION
This change adds the generate-schema-docs command to the website setup and references the generated md files in the jekyll includes for NDT5 schema documentation.

This change represents the first version of the schema docs. Updates would require editing the descriptions in m-lab/etl, tagging a new etl release, and updating the version used by the website here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/528)
<!-- Reviewable:end -->
