### PR TITLE
Specify newer version of node_js in Travis to enable firebase build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  - NODE_VERSION=v10.17.0
 
 script:
 - set -e
@@ -12,6 +13,7 @@ script:
 - sudo python3 -m pip install jupyter nbconvert
 - docker run -v $PWD:/workspace -w /workspace
     -it measurementlab/generate-schema-docs:v0.1.0 -doc.output _includes
+- nvm install $NODE_VERSION
 - npm install -g firebase-tools
 - "./_tests/travis-checks --quick"
 


### PR DESCRIPTION
The last tagged release [errored when Travis tried to build it](https://travis-ci.org/m-lab/website/builds/616692085#L750). This PR tells Travis to use a newer version of node_js so travis can deploy using the firebase module. @robertodauria PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/531)
<!-- Reviewable:end -->
