### PR TITLE
Update links to use baseurl, final ndt7 view, fix intro title

### DIFF
--- a/_posts/blog/2020-07-22-ndt7-introduction.md
+++ b/_posts/blog/2020-07-22-ndt7-introduction.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "ndt7 Introduction"
+title: "Introducing ndt7"
 author: "Lai Yi Ohlsen, Matt Mathis, Stephen Soltesz, Simone Basso"
 date: 2020-07-22
 breadcrumb: blog
@@ -65,7 +65,7 @@ affect longitudinal analysis.
 For a recent introduction to BBR see: [TCP BBR - Exploring TCP congestion
 control | by Andree Toonk][morebbr]{:target="_blank"}
 
-[ndt]: https://www.measurementlab.net/tests/ndt/
+[ndt]: {{ site.baseurl }}/tests/ndt/
 [simone]: https://github.com/bassosimone
 [morebbr]: https://medium.com/@atoonk/tcp-bbr-exploring-tcp-congestion-control-84c9c11dc3a9
 [ndt7-client-go]: https://github.com/m-lab/ndt7-client-go

--- a/_posts/blog/2020-07-24-migrating-ndt-clients-to-ndt7.md
+++ b/_posts/blog/2020-07-24-migrating-ndt-clients-to-ndt7.md
@@ -50,7 +50,7 @@ performance.
 The entry criteria use two datasets:
 
 * [measurement-lab.ndt.unified_downloads][unified_download]
-* [measurement-lab.raw_ndt.alpha_ndt7][alpha_ndt7] (preview)
+* [measurement-lab.raw_ndt.ndt7][ndt7-view]
 
 Together, these datasets allow the comparison of ndt5 and ndt7 measurements
 from the same clients.
@@ -111,7 +111,7 @@ Internet. These are generational updates of tools that help us investigate
 and understand networks and a foundation for exciting future work. We look
 forward to exploring it with you.
 
-[ndt7intro]: https://www.measurementlab.net/blog/ndt7-introduction/
-[pastmigration]: https://www.measurementlab.net/blog/global-pilot-entry/
+[ndt7intro]: {{ site.baseurl }}/blog/ndt7-introduction/
+[pastmigration]: {{ site.baseurl }}/blog/global-pilot-entry/
 [unified_download]: https://console.cloud.google.com/bigquery?folder=&organizationId=&project=measurement-lab&p=measurement-lab&d=ndt&t=unified_downloads&page=table
-[alpha_ndt7]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=raw_ndt&t=alpha_ndt7&page=table
+[ndt7-view]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=raw_ndt&t=ndt7&page=table


### PR DESCRIPTION
This change includes minor fixes in recent blog posts.

* uses `{{ site.baseurl }}` for links to past blogs.
* updates the alpha_ndt7 link to refer to the final ndt7 view (now in production).
* fixes the first blog title to "Introducing ndt7" which is gooder englishing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/604)
<!-- Reviewable:end -->
