### PR TITLE
update web100 page to correct documentation inconsistency

### DIFF
--- a/_pages/tests/ndt/web100.md
+++ b/_pages/tests/ndt/web100.md
@@ -62,13 +62,21 @@ However, some researchers may wish to query this data directly. If this is desir
 
 ## Calculating Common Metrics for NDT Web100 Data
 
-Commonly reported metrics such as upload or download speed need to be calculated from data fields saved by the web100 NDT protocol. The most commonly reported metrics are: _Download Throughput (Mbit/s)_, _Upload Throughput (Mbit/s)_, and _Round Trip Time (ms)_. Recommended queries for these metrics are outlined below, limiting results to only valid tests. For the purposes of research, we consider valid NDT web100 tests to be those that:
+If you are not using our `unified_downloads` or `unified_uploads` views, but
+instead are queryiing `measurement-lab.ndt.web100`, commonly reported metrics
+such as upload or download speed need to be calculated from data fields saved by
+the web100 NDT protocol.
 
-* Exchange of more than 8 KB of data
-* Test duration greater than 9 seconds and less than 15 seconds
-* TCP congestion was greater than 0
-* Were in a congestion limited state for at least 80% of the test duration
-* Congestion has been caused by the client for less than 20% of the test duration
+The most commonly reported metrics are: _Download Throughput (Mbit/s)_, _Upload
+Throughput (bit/s)_, and _Round Trip Time (ms)_. Recommended queries for these
+metrics are outlined below, limiting results to only valid tests. For the purposes of
+research, we consider valid NDT web100 tests to be those that:
+
+* At least 8 KB of data was transferred
+* Test duration was between 9 and 60 seconds
+* Congestion was detected
+* Tests with NULL results excluded
+* Tests from M-Lab Operations and Management infrastructure excluded
 * Traffic queuing on the switch was not present at the time of the test
 
 ## Units of Measure, Converting to megabits per second (Mbit/s)
@@ -111,21 +119,31 @@ SELECT
     web100_log_entry.snap.SndLimTimeCwnd +
     web100_log_entry.snap.SndLimTimeSnd)) AS download_Mbps
 FROM
-  `measurement-lab.ndt.recommended`
+  `measurement-lab.ndt.web100`
 WHERE
   partition_date BETWEEN '2017-01-01' AND '2017-08-28'
+  -- Data_direction specifies upload (0) or download (1) test
   AND connection_spec.data_direction = 1
+  -- Traffic queuing on the switch was not present at the time of the test
+  (blacklist_flags = 0 OR
+    (blacklist_flags IS NULL AND anomalies.blacklist_flags IS NULL))
+  -- Exclude tests from M-Lab Operations and Management infrastructure
+  AND web100_log_entry.connection_spec.local_ip IS NOT NULL
+  AND web100_log_entry.connection_spec.remote_ip IS NOT NULL
+  AND web100_log_entry.connection_spec.remote_ip NOT IN("45.56.98.222", "35.192.37.249", "35.225.75.192", "2600:3c03::f03c:91ff:fe33:819", "23.228.128.99", "2605:a601:f1ff:fffe::99")
+  -- At least 8 KB of data was transferred
   AND web100_log_entry.snap.HCThruOctetsAcked >= 8192
+  -- Test duration was between 9 and 60 seconds
   AND (web100_log_entry.snap.SndLimTimeRwin +
     web100_log_entry.snap.SndLimTimeCwnd +
     web100_log_entry.snap.SndLimTimeSnd) >= 9000000
   AND (web100_log_entry.snap.SndLimTimeRwin +
     web100_log_entry.snap.SndLimTimeCwnd +
-    web100_log_entry.snap.SndLimTimeSnd) < 600000000
+    web100_log_entry.snap.SndLimTimeSnd) < 60000000
+  -- Congestion was detected
   AND web100_log_entry.snap.CongSignals > 0
-  AND (web100_log_entry.snap.State = 1 OR
-    (web100_log_entry.snap.State >= 5 AND
-    web100_log_entry.snap.State <= 11))
+  -- Sensible TCP end state
+  AND web100_log_entry.snap.State IN (1,5,6,7,8,9,10,11)
   LIMIT 100
 ```
 
@@ -141,26 +159,9 @@ Upload throughput is calculated using this formula within the query:
 8 * (web100_log_entry.snap.HCThruOctetsReceived/web100_log_entry.snap.Duration) AS upload_Mbps
 ```
 
-The complete BigQuery example is:
-
-```sql
-#standardSQL
-SELECT
- 8 * (web100_log_entry.snap.HCThruOctetsReceived/web100_log_entry.snap.Duration) AS upload_Mbps
-FROM
-  `measurement-lab.ndt.web100`
-WHERE
-  connection_spec.client_geolocation.country_code = 'US'
-  AND partition_date BETWEEN '2017-01-01' AND '2017-01-02'
-  AND connection_spec.data_direction = 0
-  AND web100_log_entry.snap.HCThruOctetsReceived >= 8192
-  AND web100_log_entry.snap.Duration >= 9000000
-  AND web100_log_entry.snap.Duration < 600000000
-  AND (web100_log_entry.snap.State = 1
-      OR (web100_log_entry.snap.State >= 5
-      AND web100_log_entry.snap.State <= 11))
-  LIMIT 100
-```
+The complete BigQuery example is similar to the download query above. Substitute
+the upload calculation for the one used above to calculate download, and change
+`connection_spec.data_direction` to `0`.
 
 ## Round Trip Time (RTT)
 
@@ -179,7 +180,11 @@ Server-to-client RTT is affected by TCP congestion. As a consequence, there are 
 * This value can be computed as `web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT`
 * In this case, it makes sense to exclude results of tests with **10 or fewer round trip time samples**, because there are not enough samples to accurately estimate the RTT. This condition is expressed in BigQuery with:`web100_log_entry.snap.CountRTT > 10`
 
-Given that the NDT server updates the web100 variables `web100_log_entry.snap.MinRTT` and `web100_log_entry.snap.CountRTT` only when it receives an acknowledgement and given that, during client-to-server tests the NDT server receives an ack only during the 3-way-handshake, RTT values are computed only for server-to-client tests.
+Given that the NDT server updates the web100 variables
+`web100_log_entry.snap.MinRTT` and `web100_log_entry.snap.CountRTT` only when it
+receives an acknowledgement and given that, during client-to-server tests the
+NDT server receives an ack only during the 3-way-handshake, RTT values are
+computed only for server-to-client tests in the web100 datatype.
 
 The complete BigQuery example is:
 


### PR DESCRIPTION
This PR updates the web100 page to correct some inconsistencies in the query examples for those users desiring to query `measurement-lab.ndt.web100`

@mattmathis Could you please review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/633)
<!-- Reviewable:end -->
