### PR TITLE
add 2021 community call blog post

### DIFF
--- a/_pages/dates/2021-03.md
+++ b/_pages/dates/2021-03.md
@@ -1,0 +1,8 @@
+---
+layout: blog-date-archive
+title: "March 2021"
+permalink: /blog/2021/03/
+archive-name: March 2021
+archive-type: Monthly
+breadcrumb: blog
+---

--- a/_posts/blog/2021-03-03-community-call-schedule.md
+++ b/_posts/blog/2021-03-03-community-call-schedule.md
@@ -1,0 +1,50 @@
+---
+layout: blog
+title: "2021 Community Call Schedule"
+author: "Lai Yi Ohlsen"
+date: 2021-03-03
+breadcrumb: blog
+categories:
+  - community
+---
+
+In 2021, Measurement Lab will facilitate a series of community calls focusing on
+3 core topics: General M-Lab updates, Internet Measurement Research and
+Broadband Advocacy/Policy. We will rotate through these topics on the fourth
+Wednesday of every month and every meeting will take place at 11am EST for 60-90
+mins.<!--more-->
+
+To receive the Zoom call information, please fill out our [RSVP form](https://docs.google.com/forms/d/e/1FAIpQLSeHKN2MUP1IAReB8KNJM9jIdbazpaUQscdj0zZ5PbbO9K0fTA/viewform?usp=sf_link).
+
+The goal of these calls is to get to know our users better and become more
+acquainted with your use cases and questions. We welcome anyone with any level
+of expertise or background to join any session and only ask that you follow our
+[Community Guidelines]({{ site.baseurl }}/community-guidelines) when
+participating. Feel free to reach out to Project Director Lai Yi Ohlsen at
+laiyi@meausurementlab.net if you have any questions or feedback.
+
+All meetings will take place on Wednesday at 11:00 am Eastern. The full schedule is as follows:
+
+**General M-Lab updates.**
+
+Updates and discussion related to the use of M-Lab's platform, data, and community tools.
+* 24 Mar
+* 23 Jun
+* 22 Sep
+
+**Internet Measurement Research**
+
+Deep dives into topics related to Internet measurement methodology. Technical
+expertise encouraged but not required.
+* 28 Apr
+* 28 Jul
+* 27 Oct
+
+**Broadband Policy/Advocacy**
+
+Discussion and presentations related to the use of M-Lab data in digital inclusion and broadband research. Policy/advocacy expertise welcome but not required.
+* 26 May
+* 25 Aug
+* 24 Nov
+
+To receive the Zoom call information, please fill out our [RSVP form](https://docs.google.com/forms/d/e/1FAIpQLSeHKN2MUP1IAReB8KNJM9jIdbazpaUQscdj0zZ5PbbO9K0fTA/viewform?usp=sf_link).


### PR DESCRIPTION
Adds a blog post announcing the 2021 schedule of community calls. 

Depends on #641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/643)
<!-- Reviewable:end -->
