### PR TITLE
Use paris1_legacy for legacy traceroute data

### DIFF
--- a/_posts/blog/2022-02-10-v2-data-pipeline-migration.md
+++ b/_posts/blog/2022-02-10-v2-data-pipeline-migration.md
@@ -68,7 +68,7 @@ already present in the `measurement-lab.ndt_raw` dataset.
 
 | To be removed | Use instead |
 | --------------| ----------- |
-| `ndt.traceroute` (v1)	| `ndt_raw.traceroute_legacy` |
+| `ndt.traceroute` (v1)	| `ndt_raw.paris1_legacy` |
 | `ndt.ndt5` (v1)       | `ndt_raw.ndt5_legacy` |
 | `ndt.tcpinfo` (v1)    | `ndt_raw.tcpinfo_legacy` |
 | `ndt.web100` (v1)     | `ndt_raw.web100_legacy` |
@@ -105,6 +105,12 @@ naming conventions, including:
 * scamper1
 * tcpinfo
 * pcap
+
+*UPDATE*: 2022-02-28 - we changed the alternate name for the legacy
+`ndt.traceroute` view to `ndt_raw.paris1_legacy` (instead of
+`ndt_raw.traceroute_legacy`) to be consistent with the underlying datatype name
+and further move away from uses of "traceroute" as a single datatype name, when
+instead "traceroute" is a dataset consisting of many sources.
 
 [platform]: https://www.measurementlab.net/blog/the-platform-has-landed
 [v1-pipeline]: https://www.measurementlab.net/blog/etl-pipeline


### PR DESCRIPTION
This change adds an update to the v2 data pipeline migration blog post to rename `traceroute_legacy` `paris1_legacy` instead for consistency with the underlying datatype.

As explained in the update, this change is to be consistent with the underlying datatype name (paris1) and further move away from uses of "traceroute" as a single datatype name, when instead "traceroute" is a dataset consisting of many sources.

Once approved / merged, I will additionally send a notice to the original message on discuss@.

FYI: @laiyi-ohlsen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/684)
<!-- Reviewable:end -->
