### PR TITLE
Update ndt5 page for v2 schema

### DIFF
--- a/_includes/schema_ndt5resultrowv2.md
+++ b/_includes/schema_ndt5resultrowv2.md
@@ -1,0 +1,117 @@
+| Field name       | Type       | Description    |
+| :----------------|:----------:|:---------------|
+| **id** | STRING | A unique id for this test. For rows with an S2C (download) or C2S (upload) measurement, this is the UUID of that measurement. For rows without either S2C or C2s, this is the UUID of the Control channel. |
+| **a** | RECORD | Fields summarizing or derived from the raw data. |
+| a.**UUID** | STRING | UUID for TCP connection. |
+| a.**TestTime** | TIMESTAMP | The date and time of the measurement in UTC. |
+| a.**CongestionControl** | STRING | The congestion control algorithm used for connection. |
+| a.**MeanThroughputMbps** | FLOAT | The measured rate as calculated by the server. Presented in megabits per second, or Mbit/s, this value is the average of tcp-info snapshots taken at the beginning and end of an ndt7 measurement. Therefore it is identified as "MeanThroughputMbps". |
+| a.**MinRTT** | FLOAT | The minimum Round Trip Time observed during the measurement, recorded in milliseconds. |
+| a.**LossRate** | FLOAT | Loss rate from the lifetime of the connection. |
+| **parser** | RECORD | Metadata about how the parser processed this measurement row. |
+| parser.**Version** | STRING | Version is the symbolic version (if any) of the running server code that produced this measurement. |
+| parser.**Time** | TIMESTAMP | The time that the parser processed this row. |
+| parser.**ArchiveURL** | STRING | The Google Cloud Storage URL to the archive containing the Filename for this row. |
+| parser.**Filename** | STRING |  |
+| parser.**Priority** | INTEGER |  |
+| parser.**GitCommit** | STRING |  |
+| **date** | DATE | Date is used by BigQuery to partition data to improve query performance. |
+| **raw** | RECORD | Fields from the raw data. |
+| raw.**GitShortCommit** | STRING | GitShortCommit is the Git commit (short form) of the running server code that produced this measurement. |
+| raw.**Version** | STRING | Version is the symbolic version (if any) of the running server code. |
+| raw.**ServerIP** | STRING | The IP address assigned to the M-Lab server that conducted the measurement. |
+| raw.**ServerPort** | INTEGER | The port used by the server to conduct the measurement. |
+| raw.**ClientIP** | STRING | The IP address assigned to the client that conducted the measurement. |
+| raw.**ClientPort** | INTEGER | The port used by the client to conduct the measurement. |
+| raw.**StartTime** | TIMESTAMP | The date and time when the measurement began in UTC. |
+| raw.**EndTime** | TIMESTAMP | The date and time when the measurement ended in UTC. |
+| raw.**Control** | RECORD | Metadata for TCP connections to the NDT5 control channel. All NDT5 measurements have a control channel. |
+| raw.Control.**UUID** | STRING | The Universally Unique Identifier for the measurement's control channel. |
+| raw.Control.**Protocol** | STRING | The protocol used for S2C and C2S measurements. Values include WS, WSS, and PLAIN. |
+| raw.Control.**MessageProtocol** | STRING | Individual messages are sent with the MessageProtocol. Values include JSON, TLV. |
+| raw.Control.**ClientMetadata** | RECORD | Client-reported metadata as name/value pairs. |
+| raw.Control.ClientMetadata.**Name** | STRING | If set, contains text that identifies and provides context for the corresponding metadata value. For example, "OS" or "clientApplication" |
+| raw.Control.ClientMetadata.**Value** | STRING | If set, contains a value corresponding to metadata name. For example, "Windows 10" or "ndtJS" |
+| raw.Control.**ServerMetadata** | RECORD | Authoritative metadata added by the server configuration. |
+| raw.Control.ServerMetadata.**Name** | STRING | If set, contains the name of a single piece of metadata. This name will be the same for all measurements collected while this server was running with this configuration. |
+| raw.Control.ServerMetadata.**Value** | STRING | If name is set, contains the text of a server configuration value. This value will be the same for all measurements collected while this server was running with this configuration. |
+| raw.**C2S** | RECORD | Metadata for Client-to-Server (upload) measurements performed using the ndt5 protocol. |
+| raw.C2S.**ServerIP** | STRING | The IP address assigned to the M-Lab server that conducted the measurement. |
+| raw.C2S.**ServerPort** | INTEGER | The port used by the server to conduct the measurement. |
+| raw.C2S.**ClientIP** | STRING | The IP address assigned to the client that conducted the measurement. |
+| raw.C2S.**ClientPort** | INTEGER | The port used by the client to conduct the measurement. |
+| raw.C2S.**UUID** | STRING | The Universally Unique Identifier assigned to the meeasurement. |
+| raw.C2S.**StartTime** | TIMESTAMP | The date and time when the measurement began in UTC. |
+| raw.C2S.**EndTime** | TIMESTAMP | The date and time when the measurement ended in UTC. |
+| raw.C2S.**MeanThroughputMbps** | FLOAT | The measured rate as calculated by the server. Presented in megabits per second, or Mbit/s, this value is the average of tcp-info snapshots taken at the beginning and end of an ndt5 measurement. Therefore it is identified as "MeanThroughputMbps". |
+| raw.C2S.**Error** | STRING | Any error message(s) recorded during a measurement. |
+| raw.**S2C** | RECORD | Metadata for Server-to-Client (download) measurements performed using the ndt5 protocol. |
+| raw.S2C.**UUID** | STRING | The Universally Unique Identifier assigned to the meeasurement. |
+| raw.S2C.**ServerIP** | STRING | The IP address assigned to the M-Lab server that conducted the measurement. |
+| raw.S2C.**ServerPort** | INTEGER | The port used by the server to conduct the measurement. |
+| raw.S2C.**ClientIP** | STRING | The IP address assigned to the client that conducted the measurement. |
+| raw.S2C.**ClientPort** | INTEGER | The port used by the client to conduct the measurement. |
+| raw.S2C.**StartTime** | TIMESTAMP | The date and time when the measurement began in UTC. |
+| raw.S2C.**EndTime** | TIMESTAMP | The date and time when the measurement ended in UTC. |
+| raw.S2C.**MeanThroughputMbps** | FLOAT | The measured rate as calculated by the server. Presented in megabits per second, or Mbit/s, this value is the average of tcp-info snapshots taken at the beginning and end of an ndt5 measurement. Therefore it is identified as "MeanThroughputMbps". |
+| raw.S2C.**MinRTT** | INTEGER | The minimum RTT observed during the download measurement, recorded in milliseconds. |
+| raw.S2C.**MaxRTT** | INTEGER | The maximum sampled round trip time, recorded in milliseconds. |
+| raw.S2C.**SumRTT** | INTEGER | The sum of all sampled round trip times, recorded in milliseconds. |
+| raw.S2C.**CountRTT** | INTEGER | The number of round trip time samples included in S2C.SumRTT, reported in milliseconds. |
+| raw.S2C.**ClientReportedMbps** | FLOAT | The download rate as calculated by the client, in megabits per second, or Mbit/s. Not all clients report this value. |
+| raw.S2C.**TCPInfo** | RECORD | The TCPInfo record provides results from the TCP_INFO netlink socket. These are the same values returned to clients at the end of the download (S2C) measurement. |
+| raw.S2C.TCPInfo.**State** | INTEGER | TCP state is nominally 1 (Established). Other values reflect transient states having incomplete rows.<br>Kernel: See TCP_ESTABLISHED in include/net/tcp_states.h |
+| raw.S2C.TCPInfo.**CAState** | INTEGER | Loss recovery state machine. For traditional loss based congestion control algorithms, CAState is also used to control window adjustments.<br>Kernel: tcp_set_ca_state in include/net/tcp.h |
+| raw.S2C.TCPInfo.**Retransmits** | INTEGER | Number of timeouts (RTO based retransmissions) at this sequence. Reset to zero on forward progress.<br>Kernel: icsk_retransmits in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**Probes** | INTEGER | Consecutive zero window probes that have gone unanswered.<br>Kernel: icsk_probes_out in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**Backoff** | INTEGER | Exponential timeout backoff counter. Increment on RTO, reset on successful RTT measurements.<br>Kernel: icsk_backoff in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**Options** | INTEGER | Bit encoded SYN options and other negotiations TIMESTAMPS 0x1; SACK 0x2; WSCALE 0x4; ECN 0x8 - Was negotiated; ECN_SEEN - At least one ECT seen; SYN_DATA - SYN-ACK acknowledged data in SYN sent or rcvd.<br>Kernel: TCPI_OPT_TIMESTAMPS in include/uapi/linux/tcp.h |
+| raw.S2C.TCPInfo.**WScale** | INTEGER | BUG Conflation of SndWScale and RcvWScale. See github.com/m-lab/etl/issues/790 |
+| raw.S2C.TCPInfo.**AppLimited** | INTEGER | Flag indicating that rate measurements reflect non-network bottlenecks. Note that even very short application stalls invalidate max_BW measurements.<br>Kernel: rate_app_limited in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RTO** | INTEGER | Retransmission Timeout. Quantized to system jiffies.<br>Kernel: icsk_rto in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**ATO** | INTEGER | Delayed ACK Timeout. Quantized to system jiffies.<br>Kernel: ato in icsk_ack in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**SndMSS** | INTEGER | Current Maximum Segment Size. Note that this can be smaller than the negotiated MSS for various reasons.<br>Kernel: mss_cache in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RcvMSS** | INTEGER | Maximum observed segment size from the remote host. Used to trigger delayed ACKs.<br>Kernel: rcv_mss in icsk_ack in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**Unacked** | INTEGER | Number of segments between snd.nxt and snd.una. Accounting for the Pipe algorithm.<br>Kernel: packets_out in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**Sacked** | INTEGER | Scoreboard segment marked SACKED by sack blocks. Accounting for the Pipe algorithm.<br>Kernel: sacked_out in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**Lost** | INTEGER | Scoreboard segments marked lost by loss detection heuristics. Accounting for the Pipe algorithm.<br>Kernel: lost_out in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**Retrans** | INTEGER | Scoreboard segments marked retransmitted. Accounting for the Pipe algorithm.<br>Kernel: retrans_out in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**Fackets** | INTEGER |  |
+| raw.S2C.TCPInfo.**LastDataSent** | INTEGER | Time since last data segment was sent. Quantized to jiffies.<br>Kernel: lsndtime in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**LastAckSent** | INTEGER | Time since last ACK was sent (not implemented). Present in TCP_INFO but not elsewhere in the kernel. |
+| raw.S2C.TCPInfo.**LastDataRecv** | INTEGER | Time since last data segment was received. Quantized to jiffies.<br>Kernel: lrcvtime in icsk_ack in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**LastAckRecv** | INTEGER |  |
+| raw.S2C.TCPInfo.**PMTU** | INTEGER | Maximum IP Transmission Unit for this path.<br>Kernel: icsk_pmtu_cookie in include/net/inet_connection_sock.h |
+| raw.S2C.TCPInfo.**RcvSsThresh** | INTEGER | Current Window Clamp. Receiver algorithm to avoid allocating excessive receive buffers.<br>Kernel: rcv_ssthresh in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RTT** | INTEGER | Smoothed Round Trip Time (RTT). The Linux implementation differs from the standard.<br>Kernel: srtt_us in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RTTVar** | INTEGER | RTT variance. The Linux implementation differs from the standard.<br>Kernel: mdev_us in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**SndSsThresh** | INTEGER | Slow Start Threshold. Value controlled by the selected congestion control algorithm.<br>Kernel: snd_ssthresh in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**SndCwnd** | INTEGER | Congestion Window. Value controlled by the selected congestion control algorithm.<br>Kernel: snd_cwnd in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**AdvMSS** | INTEGER | Advertised MSS.<br>Kernel: advmss in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**Reordering** | INTEGER | Maximum observed reordering distance.<br>Kernel: reordering in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RcvRTT** | INTEGER | Receiver Side RTT estimate.<br>Kernel: rcv_rtt_est.rtt_us in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**RcvSpace** | INTEGER | Space reserved for the receive queue. Typically updated by receiver side auto-tuning.<br>Kernel: space in rcvq_space in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**TotalRetrans** | INTEGER | Total number of segments containing retransmitted data.<br>Kernel: total_retrans in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**PacingRate** | INTEGER | Current Pacing Rate, nominally updated by congestion control.<br>Kernel: sk_pacing_rate in include/net/sock.h |
+| raw.S2C.TCPInfo.**MaxPacingRate** | INTEGER | Settable pacing rate clamp. Set with setsockopt( ..SO_MAX_PACING_RATE.. ).<br>Kernel: sk_max_pacing_rate in include/net/sock.h |
+| raw.S2C.TCPInfo.**BytesAcked** | INTEGER | The number of data bytes for which cumulative acknowledgments have been received.<br>Kernel: bytes_acked in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**BytesReceived** | INTEGER | The number of data bytes for which have been received.<br>Kernel: bytes_received in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**SegsOut** | INTEGER | The number of segments transmitted. Includes data and pure ACKs.<br>Kernel: segs_out in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**SegsIn** | INTEGER | The number of segments received. Includes data and pure ACKs.<br>Kernel: segs_in in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**NotsentBytes** | INTEGER | Number of bytes queued in the send buffer that have not been sent.<br>Kernel: tcpi_notsent_bytes() in net/ipv4/tcp.c |
+| raw.S2C.TCPInfo.**MinRTT** | INTEGER | Minimum Round Trip Time. From an older, pre-BBR algorithm.<br>Kernel: tcp_min_rtt in include/net/tcp.h |
+| raw.S2C.TCPInfo.**DataSegsIn** | INTEGER | Input segments carrying data (len>0).<br>Kernel: data_segs_in in include/net/tcp.h |
+| raw.S2C.TCPInfo.**DataSegsOut** | INTEGER | Transmitted segments carrying data (len>0).<br>Kernel: data_segs_out in include/net/tcp.h |
+| raw.S2C.TCPInfo.**DeliveryRate** | INTEGER | Observed Maximum Delivery Rate.<br>Kernel: tcp_compute_delivery_rate() in net/ipv4/tcp.c |
+| raw.S2C.TCPInfo.**BusyTime** | INTEGER | Time with outstanding (unacknowledged) data. Time when snd.una is not equal to snd.next.<br>Kernel: tcp_get_info_chrono_stats() in net/ipv4/tcp.c |
+| raw.S2C.TCPInfo.**RWndLimited** | INTEGER | Time spend waiting for receiver window.<br>Kernel: tcp_get_info_chrono_stats() in net/ipv4/tcp.c |
+| raw.S2C.TCPInfo.**SndBufLimited** | INTEGER | Time spent waiting for sender buffer space. This only includes the time when TCP transmissions are starved for data, but the application has been stopped because the buffer is full and can not be grown for some reason.<br>Kernel: tcp_get_info_chrono_stats() in net/ipv4/tcp.c |
+| raw.S2C.TCPInfo.**Delivered** | INTEGER | Data segments delivered to the receiver including retransmits. As reported by returning ACKs, used by ECN.<br>Kernel: delivered in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**DeliveredCE** | INTEGER | ECE marked data segments delivered to the receiver including retransmits. As reported by returning ACKs, used by ECN.<br>Kernel: delivered_ce in include/linux/tcp.h |
+| raw.S2C.TCPInfo.**BytesSent** | INTEGER | Payload bytes sent (excludes headers, includes retransmissions).<br>Kernel: bytes_sent |
+| raw.S2C.TCPInfo.**BytesRetrans** | INTEGER | Bytes retransmitted. May include headers and new data carried with a retransmission (for thin flows).<br>Kernel: bytes_retrans |
+| raw.S2C.TCPInfo.**DSackDups** | INTEGER | Duplicate segments reported by DSACK. Not reported by some Operating Systems.<br>Kernel: dsack_dups |
+| raw.S2C.TCPInfo.**ReordSeen** | INTEGER | Received ACKs that were out of order. Estimates reordering on the return path.<br>Kernel: reord_seen |
+| raw.S2C.TCPInfo.**RcvOooPack** | INTEGER |  |
+| raw.S2C.TCPInfo.**SndWnd** | INTEGER |  |
+| raw.S2C.**Error** | STRING | Any error message(s) recorded during a measurement. |

--- a/_includes/schema_ndt7resultrow.md
+++ b/_includes/schema_ndt7resultrow.md
@@ -164,6 +164,9 @@
 | raw.Upload.**ClientMetadata** | RECORD | Client-reported metadata as name/value pairs. |
 | raw.Upload.ClientMetadata.**Name** | STRING | If set, contains text that identifies and provides context for the corresponding metadata value. For example, "OS" or "clientApplication" |
 | raw.Upload.ClientMetadata.**Value** | STRING | If set, contains a value corresponding to metadata name. For example, "Windows 10" or "ndtJS" |
+| raw.Upload.**ServerMetadata** | RECORD | Authoritative metadata added by the server configuration. |
+| raw.Upload.ServerMetadata.**Name** | STRING | If set, contains the name of a single piece of metadata. This name will be the same for all measurements collected while this server was running with this configuration. |
+| raw.Upload.ServerMetadata.**Value** | STRING | If name is set, contains the text of a server configuration value. This value will be the same for all measurements collected while this server was running with this configuration. |
 | raw.**Download** | RECORD |  |
 | raw.Download.**UUID** | STRING | UUID for TCP connection for this measurement. |
 | raw.Download.**StartTime** | TIMESTAMP | The date and time when the measurement began in UTC. |
@@ -303,3 +306,6 @@
 | raw.Download.**ClientMetadata** | RECORD | Client-reported metadata as name/value pairs. |
 | raw.Download.ClientMetadata.**Name** | STRING | If set, contains text that identifies and provides context for the corresponding metadata value. For example, "OS" or "clientApplication" |
 | raw.Download.ClientMetadata.**Value** | STRING | If set, contains a value corresponding to metadata name. For example, "Windows 10" or "ndtJS" |
+| raw.Download.**ServerMetadata** | RECORD | Authoritative metadata added by the server configuration. |
+| raw.Download.ServerMetadata.**Name** | STRING | If set, contains the name of a single piece of metadata. This name will be the same for all measurements collected while this server was running with this configuration. |
+| raw.Download.ServerMetadata.**Value** | STRING | If name is set, contains the text of a server configuration value. This value will be the same for all measurements collected while this server was running with this configuration. |

--- a/_pages/tests/ndt/ndt.md
+++ b/_pages/tests/ndt/ndt.md
@@ -232,6 +232,14 @@ current BigQuery Views, please review the pages below:
 * [ndt7-client-go](https://github.com/m-lab/ndt7-client-go){:target="_blank"}
 * [ndt7-js](https://github.com/m-lab/ndt7-js/){:target="_blank"}
 
+**NDT Community-Supported Clients**
+* https://github.com/m-lab/ndt7-client-ios (swift)
+* https://github.com/m-lab/ndt7-client-android (kotlin)
+* https://github.com/m-lab/ndt7-client-android-java (java)
+* https://github.com/measurement-kit/libndt/blob/master/single_include/libndt.hpp (c++, missing [Locate v2][locatev2] support, help welcome)
+
+[locatev2]: https://github.com/m-lab/locate/blob/master/USAGE.md
+
 ## Citing the M-Lab NDT Dataset
 
 Please cite the NDT data set as follows: **The M-Lab NDT Data Set, &lt;date range used&gt; https://measurementlab.net/tests/ndt**

--- a/_pages/tests/ndt/ndt.md
+++ b/_pages/tests/ndt/ndt.md
@@ -37,15 +37,18 @@ the new one we are now using. We now refer to these as "datatypes" for the NDT t
   * Used the Reno TCP congestion control algorithm
   * Ran from 2009-02-18 to 2019-11-20
 * [ndt5]({{ site.baseurl }}/tests/ndt/ndt5) is an NDT protocol designed to be backward compatible with legacy NDT clients
-  * Relies on tcp-info for TCP statistics
-  * Collected using [ndt-server](https://github.com/m-lab/ndt-server), which follows the legacy NDT protocol to support existing NDT clients that use it
+  * Relies on [tcp-info][tcp-info] for TCP statistics
+  * Collected using [ndt-server][ndt-server], which follows the legacy NDT protocol to support existing NDT clients that use it
   * Uses the Cubic TCP congestion control algorithm
-  * Started 2019-07-18 and continues to present. The evolution to ndt7 is driven by client upgrades and is expected to have a very long tail
+  * Started 2019-07-18 and continues to present.
 * [ndt7]({{ site.baseurl }}/tests/ndt/ndt7) is an NDT protocol that uses TCP BBR where available, operates on standard HTTP(S) ports (80, 443)
-  * Relies on tcp-info for TCP statistics
-  * Collected using [ndt-server](https://github.com/m-lab/ndt-server)
+  * Relies on [tcp-info][tcp-info] for TCP statistics
+  * Collected using [ndt-server][ndt-server]
   * Uses the BBR TCP congestion control algorithm, falling back to Cubic when BBR is not available on the client side
-  * Started 2020-02-18 and continues to present
+  * Started 2020-02-18 and continues to present.
+
+[ndt-server]: https://github.com/m-lab/ndt-server
+[tcp-info]: {{ site.baseurl }}/tests/tcp-info
 
 ## Data Collected by NDT
 
@@ -147,7 +150,7 @@ of the terminology has evolved slightly since the blog posts.
 
 NDT Extended Views are published in the `ndt_intermediate` dataset, and
 contain every row from the raw views, with added columns
-describing everything that we know about the data. 
+describing everything that we know about the data.
 
 <span style="color: black;">**Custom unified views based on the NDT Extended Views
 should be the starting point for nearly all alternative analyses of M-Lab
@@ -178,7 +181,7 @@ Research][custom-views-subqueries]
   * `measurement-lab.ndt_intermediate.extended_web100_uploads`
 
 [custom-views-subqueries]: {{ site.baseurl }}/tests/ndt/views/custom
-  
+
 ## Raw Views
 
 NDT Raw Views are published in the `ndt_raw` dataset, and provide a 1-to-1

--- a/_pages/tests/ndt/ndt5.md
+++ b/_pages/tests/ndt/ndt5.md
@@ -1,36 +1,34 @@
 ---
 layout: page
 permalink: /tests/ndt/ndt5/
-title: "ndt5 Protocol - NDT (Network Diagnostic Tool)"
+title: "ndt5 Data - NDT (Network Diagnostic Tool)"
 breadcrumb: tests
 ---
 
-# ndt5 Protocol - NDT (Network Diagnostic Tool)
+# ndt5 Data - NDT (Network Diagnostic Tool)
 
-The ndt5 protocol in the [ndt-server][ndt5-server]{:target="_blank"} supports
-many NDT clients which used the previous NDT server based on web100. As a part
-of M-Lab's platform upgrade in 2019, [ndt-server][ndt-server]{:target="_blank"}
-replaced the web100 based ndt4 protocol with the ndt5 protocol based on [TCP
-INFO][tcp-info]{:target="_blank"}. New client integrations are encouraged to use
-the [ndt7 protocol][ndt7-clients]{:target="_blank"}.
+Since M-Lab's platform upgrade in 2019, the ndt5 protocol continues to support
+many NDT clients that used earlier [NDT protocol versions][ndt-evolution].
+Measurements from the ndt5 protocol are based on [TCP INFO][tcp-info]
+instrumentation.
 
-NDT data collected before **2019-07-19** used the Web100 Linux kernel patch for
-TCP instrumentation. This data can be found in the [NDT web100 dataset]({{
-site.baseurl }}/tests/ndt/web100).
+*NOTE*: New client integrations are strongly encouraged to use the [ndt7
+protocol][ndt7-clients]{:target="_blank"} for better support, ease of
+integraiton, and client performance.
 
-NDT data using the ndt5 protocol collected on or after **2019-07-19** uses
-[tcp-info][tcp-info]{:target="_blank"} for all TCP instrumentation and is
-available in both [raw format in Google Cloud Storage][cloud-storage]{:target="_blank"}
-and in [queryable format in BigQuery][bqtable]{:target="_blank"}.
+* [ndt5 raw data in Cloud Storage][ndt5-storage]
 
+[ndt-evolution]: {{ site.baseurl }}/blog/evolution-of-ndt/
 [ndt5-server]: https://github.com/m-lab/ndt-server/tree/master/ndt5/
 [ndt-server]: https://github.com/m-lab/ndt-server/
 [tcp-info]: {{ site.baseurl }}/tests/tcp-info
-[cloud-storage]: https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt
-[bqtable]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5&page=table
+[ndt5-storage]: https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt/ndt5
+[ndt5-table]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5&page=table
 [ndt7-clients]: {{ site.baseurl }}/tests/ndt/#source-code
 
 ## ndt5 BigQuery Schema
+
+* [ndt5 parsed & annotated dataset in BigQuery][ndt5-table]
 
 <div class="table-responsive" markdown="1">
 {% include schema_ndt5resultrowv2.md %}

--- a/_pages/tests/ndt/ndt5.md
+++ b/_pages/tests/ndt/ndt5.md
@@ -7,29 +7,28 @@ breadcrumb: tests
 
 # ndt5 Protocol - NDT (Network Diagnostic Tool)
 
-The ndt5 protocol in [ndt-server][ndt5-server]{:target="_blank"} supports the
-many NDT clients which use the previous web100 legacy NDT server. As a part of
-M-Lab's platform upgrade in 2019, [ndt-server][ndt-server]{:target="_blank"}
-replaced the former web100 based ndt4 protocol with the ndt5 protocol, and later
-added the ndt7 protocol. New clients are encouraged to use the ndt7 protocol.
+The ndt5 protocol in the [ndt-server][ndt5-server]{:target="_blank"} supports
+many NDT clients which used the previous NDT server based on web100. As a part
+of M-Lab's platform upgrade in 2019, [ndt-server][ndt-server]{:target="_blank"}
+replaced the web100 based ndt4 protocol with the ndt5 protocol based on [TCP
+INFO][tcp-info]{:target="_blank"}. New client integrations are encouraged to use
+the [ndt7 protocol][ndt7-clients]{:target="_blank"}.
 
 NDT data collected before **2019-07-19** used the Web100 Linux kernel patch for
-TCP statistics. This data can be found in the [NDT web100 (legacy) dataset]({{
+TCP instrumentation. This data can be found in the [NDT web100 dataset]({{
 site.baseurl }}/tests/ndt/web100).
 
 NDT data using the ndt5 protocol collected on or after **2019-07-19** uses
-[tcp-info]({{ site.baseurl }}/learn) for all TCP metrics and is available in
-both [raw format in Google Cloud Storage][cloud-storage]{:target="_blank"} and
-in [queryable format in BigQuery][bqtable]{:target="_blank"}.
-
-More details about the ndt5 protocol can be found in the [README for ndt5 on
-Github][ndt5-metrics]{:target="_blank"}.
+[tcp-info][tcp-info]{:target="_blank"} for all TCP instrumentation and is
+available in both [raw format in Google Cloud Storage][cloud-storage]{:target="_blank"}
+and in [queryable format in BigQuery][bqtable]{:target="_blank"}.
 
 [ndt5-server]: https://github.com/m-lab/ndt-server/tree/master/ndt5/
 [ndt-server]: https://github.com/m-lab/ndt-server/
+[tcp-info]: {{ site.baseurl }}/tests/tcp-info
 [cloud-storage]: https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt
 [bqtable]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5&page=table
-[ndt5-metrics]: https://github.com/m-lab/ndt-server/tree/master/ndt5#ndt5-metrics
+[ndt7-clients]: {{ site.baseurl }}/tests/ndt/#source-code
 
 ## ndt5 BigQuery Schema
 

--- a/_pages/tests/ndt/ndt5.md
+++ b/_pages/tests/ndt/ndt5.md
@@ -7,17 +7,31 @@ breadcrumb: tests
 
 # ndt5 Protocol - NDT (Network Diagnostic Tool)
 
-The ndt5 protocol in [ndt-server](https://github.com/m-lab/ndt-server/tree/master/ndt5/){:target="_blank"} supports the many NDT clients which use the previous web100 legacy NDT server. As a part of M-Lab's platform upgrade in 2019, [ndt-server](https://github.com/m-lab/ndt-server/){:target="_blank"} replaced the former web100 based ndt4 protocol with the ndt5 protocol, and added the ndt7 protocol for future client use. New clients will be encouraged to use the ndt7 protocol once the platform transition is completed.
+The ndt5 protocol in [ndt-server][ndt5-server]{:target="_blank"} supports the
+many NDT clients which use the previous web100 legacy NDT server. As a part of
+M-Lab's platform upgrade in 2019, [ndt-server][ndt-server]{:target="_blank"}
+replaced the former web100 based ndt4 protocol with the ndt5 protocol, and later
+added the ndt7 protocol. New clients are encouraged to use the ndt7 protocol.
 
-NDT data collected before **2019-07-19** used the Web100 Linux kernel patch for TCP statistics. This data can be found in the [NDT web100 (legacy) dataset]({{ site.baseurl }}/tests/ndt/web100).
+NDT data collected before **2019-07-19** used the Web100 Linux kernel patch for
+TCP statistics. This data can be found in the [NDT web100 (legacy) dataset]({{
+site.baseurl }}/tests/ndt/web100).
 
-NDT data using the ndt5 protocol collected on or after **2019-07-19** uses [tcp-info]({{ site.baseurl }}/learn) for all TCP metrics is available in both [raw format in Google Cloud Storage](https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt){:target="_blank"} and in [queryable format in BigQuery](https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5&page=table){:target="_blank"}.
+NDT data using the ndt5 protocol collected on or after **2019-07-19** uses
+[tcp-info]({{ site.baseurl }}/learn) for all TCP metrics and is available in
+both [raw format in Google Cloud Storage][cloud-storage]{:target="_blank"} and
+in [queryable format in BigQuery][bqtable]{:target="_blank"}.
 
-More details about the ndt5 protocol can be found in the [README for ndt5 on Github](https://github.com/m-lab/ndt-server/tree/master/ndt5#ndt5-metrics){:target="_blank"}.
+More details about the ndt5 protocol can be found in the [README for ndt5 on
+Github][ndt5-metrics]{:target="_blank"}.
+
+[ndt5-server]: https://github.com/m-lab/ndt-server/tree/master/ndt5/
+[ndt-server]: https://github.com/m-lab/ndt-server/
+[cloud-storage]: https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt
+[bqtable]: https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5&page=table
+[ndt5-metrics]: https://github.com/m-lab/ndt-server/tree/master/ndt5#ndt5-metrics
 
 ## ndt5 BigQuery Schema
-
-**Note:** The ndt5 schema has not yet been migrated to standard columns. Until that time, this schema should be considered temporary or unstable.
 
 <div class="table-responsive" markdown="1">
 {% include schema_ndt5resultrow.md %}

--- a/_pages/tests/ndt/ndt5.md
+++ b/_pages/tests/ndt/ndt5.md
@@ -34,5 +34,5 @@ Github][ndt5-metrics]{:target="_blank"}.
 ## ndt5 BigQuery Schema
 
 <div class="table-responsive" markdown="1">
-{% include schema_ndt5resultrow.md %}
+{% include schema_ndt5resultrowv2.md %}
 </div>


### PR DESCRIPTION
This change updates the ndt5 page to include the v2 schema. This change also updates the page leading text for formatting, clarity, and additional helpful links.

See:
* http://website.mlab-sandbox.measurementlab.net/tests/ndt/ndt5/

Part of:
* https://github.com/m-lab/etl/issues/1046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/686)
<!-- Reviewable:end -->
