### PR TITLE
Update reference to traceroute_legacy

### DIFF
--- a/_pages/tests/ndt/ndt.md
+++ b/_pages/tests/ndt/ndt.md
@@ -207,7 +207,7 @@ has been parsed and imported into BigQuery.
   * `measurement-lab.ndt_raw.ndt5_legacy`
   * `measurement-lab.ndt_raw.web100_legacy`
   * `measurement-lab.ndt_raw.tcpinfo_legacy`
-  * `measurement-lab.ndt_raw.traceroute_legacy`
+  * `measurement-lab.ndt_raw.paris1_legacy`
   * `measurement-lab.ndt_raw.annotation`
 
 ## Example Queries and Updating Past Queries


### PR DESCRIPTION
Now that `paris1_legacy` exists as a replacement to `traceroute_legacy`, we should update our documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/694)
<!-- Reviewable:end -->
