### PR TITLE
Update 2022-02-16-run-a-private-ndt-server.md

### DIFF
--- a/_posts/blog/2022-02-16-run-a-private-ndt-server.md
+++ b/_posts/blog/2022-02-16-run-a-private-ndt-server.md
@@ -73,9 +73,7 @@ in the command below, and change the ports if desired. Please note that some
 components of the ndt fullstack image must be run as root.
 
 ```~bash
-sudo docker run -d --network=bridge                \
-           -p 8080:8080 -p 4443:4443               \
-           -p 3001:3001 -p 3002:3002 -p 3010:3010  \
+sudo docker run -d --network=host                \
            --volume `pwd`/certs:/certs:ro          \
            --volume `pwd`/datadir:/var/spool/ndt   \
            --volume `pwd`/var-local:/var/local     \


### PR DESCRIPTION
Update docker command to use `--network=host` so NDT5 can work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/698)
<!-- Reviewable:end -->
