### PR TITLE
Replace token with service account credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ deploy:
 ## - production
 - provider: script
   skip_cleanup: true
-  script: "firebase use mlab-oti && firebase deploy --only hosting --token $FIREBASE_TOKEN"
+  script:
+    ( set +x; echo "${SERVICE_ACCOUNT_mlab_oti}" > /tmp/sa.json ) &&
+    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json &&
+    firebase use mlab-oti &&
+    firebase deploy --only hosting
   on:
     repo: m-lab/website
     tags: true


### PR DESCRIPTION
Token based authentication is now deprecated for the firebase toolchain. When attempting a deployment using the FIREBASE_TOKEN, now results in 401 errors and error messages like:

```
⚠  Authenticating with `FIREBASE_TOKEN` is deprecated and will be removed in a future major version of `firebase-tools`. Instead, use a service account key with `GOOGLE_APPLICATION_CREDENTIALS`

Error: Invalid project selection, please verify project mlab-oti exists and you have access.
```

This change migrates the production deployment to use service account credentials. The FIREBASE_TOKEN environment variable has been deleted from the travis settings for this repo and the mlab-oti service account updated with the correct service account for this deployment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/712)
<!-- Reviewable:end -->
