### PR TITLE
Add deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,7 @@ deploy:
 ## - production
 - provider: script
   skip_cleanup: true
-  script:
-    ( set +x; echo "${SERVICE_ACCOUNT_mlab_oti}" > /tmp/sa.json ) &&
-    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json &&
-    firebase use mlab-oti &&
-    firebase deploy --only hosting
+  script: "$TRAVIS_BUILD_DIR/firebase-deploy.sh"
   on:
     repo: m-lab/website
     tags: true

--- a/firebase-deploy.sh
+++ b/firebase-deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+tmpdir=$( mktemp )
+echo "${SERVICE_ACCOUNT_mlab_oti}" > $tmpdir/sa.json
+
+set -x
+export GOOGLE_APPLICATION_CREDENTIALS=$tmpdir/sa.json
+firebase use mlab-oti && firebase deploy --only hosting

--- a/firebase-deploy.sh
+++ b/firebase-deploy.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
-tmpdir=$( mktemp )
-echo "${SERVICE_ACCOUNT_mlab_oti}" > $tmpdir/sa.json
+tmpfile=$( mktemp )
+echo "${SERVICE_ACCOUNT_mlab_oti}" > $tmpfile
 
 set -x
-export GOOGLE_APPLICATION_CREDENTIALS=$tmpdir/sa.json
+export GOOGLE_APPLICATION_CREDENTIALS=$tmpfile
 firebase use mlab-oti && firebase deploy --only hosting

--- a/firebase-deploy.sh
+++ b/firebase-deploy.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
-tmpfile=$( mktemp )
-echo "${SERVICE_ACCOUNT_mlab_oti}" > $tmpfile
+tmpdir=$( mktemp -d )
+echo "${SERVICE_ACCOUNT_mlab_oti}" > $tmpdir/sa.json
 
 set -x
-export GOOGLE_APPLICATION_CREDENTIALS=$tmpfile
+export GOOGLE_APPLICATION_CREDENTIALS=$tmpdir/sa.json
 firebase use mlab-oti && firebase deploy --only hosting


### PR DESCRIPTION
The inline approach used in https://github.com/m-lab/website/pull/712 to store the service account credentials did not work as intended with travis's script interpreter. This change simply places the deploy steps into a separate shell script, `firebase-deploy.sh`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/713)
<!-- Reviewable:end -->
