### PR TITLE
Update location of legacy m-lab_revtr data

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -38,7 +38,7 @@ There is typically at least a 24-hour delay between data collection and data pub
   * Reverse traceroute measures the network path back to a user from selected network endpoints, and provides a rich source of information on network routing and topology.
   * Reverse Traceroute data is not processed by the M-Lab ETL Pipeline.
   * More information is available at [Reverse Traceroute](https://research.cs.washington.edu/networking/astronomy/reverse-traceroute.html){:target="_blank"}
-  * [Reverse Traceroute Raw Data](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
+  * [Reverse Traceroute Raw Data](https://console.cloud.google.com/storage/browser/thirdparty-revtr0-measurement-lab){:target="_blank"}
 * [WeHe]({{site.baseurl}}/tests/wehe)
   * Wehe uses your device to exchange Internet traffic recorded from real, popular apps like YouTube and Spotify, and attempts to tell you whether your ISP is giving different performance to an app's network traffic.
   * More information is available from the [WeHe website](https://dd.meddle.mobi/){:target="_blank"} and [GitHub](https://dd.meddle.mobi/codeanddata.html){:target="_blank"}.

--- a/_pages/tests/reverse_traceroute.md
+++ b/_pages/tests/reverse_traceroute.md
@@ -11,7 +11,7 @@ Reverse traceroute measures the network path back to a user from selected networ
 
 Please cite this data set as follows: **The M-Lab Reverse Traceroute Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/reverse_traceroute**
 
-**Data** collected by Reverse Traceroute is available in raw format at[https://console.cloud.google.com/storage/browser/m-lab_revtr/](https://console.cloud.google.com/storage/browser/m-lab_revtr/).
+**Data** collected by Reverse Traceroute is available in raw format at[https://console.cloud.google.com/storage/browser/thirdparty-revtr0-measurement-lab](https://console.cloud.google.com/storage/browser/thirdparty-revtr0-measurement-lab).
 
 If you are interested in accessing data from the Reverse Traceroute test in BigQuery, please [contact us](mailto:support@measurementlab.net)!
 


### PR DESCRIPTION
This change updates the location of the legacy revtr exported data to a GCS bucket in the measurement-lab project. This bucket is no longer updated.

FYI: The revtr team is uploading some new exported data to https://console.cloud.google.com/storage/browser/thirdparty-revtr-mlab-oti but this is not yet part of the public archive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/726)
<!-- Reviewable:end -->
