### PR TITLE
Show site status unclustered

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Current Build Status is: [![Build Status](https://secure.travis-ci.org/m-lab/web
 ## Contributing
 
 To learn about how to setup your environment, and our standards and practices for contributing, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+

--- a/_includes/infrastructure-map.js
+++ b/_includes/infrastructure-map.js
@@ -1,4 +1,3 @@
-<script>
 mapboxgl.accessToken = 'pk.eyJ1IjoibS1sYWIiLCJhIjoiY2p3eWtxOXZ4MDFkMzQ5cG95ODFhbWJieiJ9.9G1YGnkme4goR0Ly3kqovA';
 var map = new mapboxgl.Map({
   container: 'map',
@@ -18,8 +17,7 @@ map.on('load', function () {
     type: "geojson",
     data: url,
     cluster: true,
-    clusterRadius: 10,
-    clusterMaxZoom: 15,
+    clusterRadius: 1,
     clusterProperties: {
       'oneG': ['+', ['case', oneG, 1, 0]],
       'tenG': ['+', ['case', tenG, 1, 0]],
@@ -136,4 +134,3 @@ map.on('load', function () {
     map.getCanvas().style.cursor = '';
   });
 });
-</script>

--- a/_pages/status.md
+++ b/_pages/status.md
@@ -16,7 +16,9 @@ The M-Lab infrastructure map displays information about our server pods around t
 <div id="map" class="map leaflet-container" style="height: 500px; width:100%; position:relative;"></div>
 </p>
 
+<script>
 {% include infrastructure-map.js %}
+</script>
 
 ## M-Lab Naming Service
 


### PR DESCRIPTION
With the retirement of support for mlab-ns and the removal of virtual nodes from the mlab-ns world map, M-Lab staff still depend on a complete and easy to use global map of server and site locations.

The previous configuration clustered sites across sites, making the default view very difficult to use as a replacement for mlab-ns. This change reduces the `clusterRadius` to its minimum so that separate sites do not cluster together.