### PR TITLE
Pin firebase-tools version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - sudo apt-get install -y python3-pip jupyter jupyter-nbconvert
 - sudo -H python3 -m pip install --upgrade setuptools pip
 - nvm install $NODE_VERSION
-- npm install -g firebase-tools
+- npm install -g firebase-tools@11.30.0
 - "./_tests/travis-checks --quick"
 
 deploy:


### PR DESCRIPTION
Today's [deployment of the website failed](https://app.travis-ci.com/github/m-lab/website/builds/263469498) due to an incompatibility between nodejs v14 and the latest version of `firebase-tools@12.2.1`. Since the build currently pins the version of nodejs to v14 and the [last successful deployment](https://app.travis-ci.com/github/m-lab/website/builds/262878147) from May 8th used `firebase-tools@11.30.0`, this change pins the firebase-tools package to this version. Unfortunately, since firebase is only used on production deployments there is no way to test this in advance, but this change appears low risk.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/750)
<!-- Reviewable:end -->
