### PR TITLE
Add text labels to metros with a single site

### DIFF
--- a/_includes/infrastructure-map.js
+++ b/_includes/infrastructure-map.js
@@ -2,8 +2,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoibS1sYWIiLCJhIjoiY2p3eWtxOXZ4MDFkMzQ5cG95ODFhb
 var map = new mapboxgl.Map({
   container: 'map',
   style: 'mapbox://styles/mapbox/dark-v10',
-  center: [12,25],
-  zoom: 0.8
+  center: [5,17],
+  zoom: 1.2
 });
 
 var url = 'https://siteinfo.mlab-oti.measurementlab.net/v1/sites/geo.json';
@@ -32,20 +32,16 @@ map.on('load', function () {
       "circle-radius": [
         "step",
         ["get", "point_count"],
-        5,
-        2,
-        10,
-        6,
-        15
+        7,     /* lt 3 -> 7 */
+        3, 11, /* gte 3 -> 11 */
+        6, 15, /* gte 6 -> 15 */
       ],
       "circle-color": [
         "step",
           ["get","point_count"],
           "#deebf7",
-          2,
-          "#9ecae1",
-          6,
-          "#3182bd"
+          3, "#9ecae1",
+          6, "#3182bd"
       ]}
   });
   map.addLayer({
@@ -66,10 +62,21 @@ map.on('load', function () {
     "source": "mlab-sites",
     "filter": ["!", ["has", "point_count"]],
     "paint": {
-      "circle-radius": 5,
+      "circle-radius": 7,
       "circle-color": "#deebf7",
-      "circle-stroke-width": 1,
-      "circle-stroke-color": "#000"
+      "circle-stroke-width": 0
+    }
+  });
+  map.addLayer({
+    "id": "unclustered-count",
+    "type": "symbol",
+    "source": "mlab-sites",
+    "filter": ["!", ["has", "point_count"]],
+    "layout": {
+      "text-field": "1",
+      "text-font": ["DIN Offc Pro Medium",
+        "Arial Unicode MS Bold"],
+        "text-size": 12
     }
   });
 


### PR DESCRIPTION
The default mode for mapbox status map is to leave unclustered metros without a label. Without a label, these locations are ambiguous -- are they M-lab sites or city locations on the underlying geography? As we migrate away from mlab-ns as the canonical map of server locations, it is helpful to improve the clarity of this status map.

This change makes several small configuration updates to:
* add a label of "1" on unclustered metros (where there is a single site)
* recenter the map so we can zoom in slight so more metros show in the default view
* increases the default circle size slightly: radius 7 (for metros with 1-2 sites), 14 (for metros 3-5 sites), 21 greater or equal to 6.

An example of this change is below and on the sandbox website.

Original view:
<img width="1147" alt="Screen Shot 2023-08-14 at 4 53 30 PM" src="https://github.com/m-lab/website/assets/1085316/23a4e5b4-a85a-4669-bc03-ee29d2fb54d6">


Updated view:
<img width="1146" alt="Screen Shot 2023-08-14 at 4 47 00 PM" src="https://github.com/m-lab/website/assets/1085316/58c56593-51be-4bc0-b579-580cba6420e5">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/759)
<!-- Reviewable:end -->
