### PR TITLE
Updates Mapbox token adding origin restrictions

### DIFF
--- a/_includes/infrastructure-map.js
+++ b/_includes/infrastructure-map.js
@@ -1,4 +1,4 @@
-mapboxgl.accessToken = 'pk.eyJ1IjoibS1sYWIiLCJhIjoiY2p3eWtxOXZ4MDFkMzQ5cG95ODFhbWJieiJ9.9G1YGnkme4goR0Ly3kqovA';
+mapboxgl.accessToken = 'pk.eyJ1IjoibS1sYWIiLCJhIjoiY2xsdmN2NXBuMTl1ZDNmcGh1ZmxmaGwzcSJ9.3xXvAS4T6tZoahEeevGa4A';
 var map = new mapboxgl.Map({
   container: 'map',
   style: 'mapbox://styles/mapbox/dark-v10',


### PR DESCRIPTION
https://github.com/m-lab/website/issues/765

I generated a new token in our Mapbox account which is restricted to origin domains:

* measurementlab.net
* appspot.com
* localhost

I'm not sure what at appspot.com that might be accessing our Mapbox account using our API key, but Mapbox says that some small trickle of less than 1% of requests are coming from that domain.  Similarly, Mapbox reports that 10% of all requests using our current API key are coming from localhost. I'm not sure what that means wither, unless it is local testing or builds? In both cases, if we merge this PR, then requests coming from those domains _could_ start failing if they are independent of the changes in this PR.

The map seems to work fine in sandbox after I pushed this PR:

http://website.mlab-sandbox.measurementlab.net/status/

I have also verified that accessing [Mapbox API URLs](https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2/1/0/0.vector.pbf?sku=101hVcWp3SjNA&access_token=pk.eyJ1IjoibS1sYWIiLCJhIjoiY2xsdmN2NXBuMTl1ZDNmcGh1ZmxmaGwzcSJ9.3xXvAS4T6tZoahEeevGa4A) from my local machine using curl returns a 401 Unauthorized response.

Once we feel okay about this PR we can rotate our current public API key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/767)
<!-- Reviewable:end -->
