### PR TITLE
Pin version of bundler to work with ruby2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - NODE_VERSION=v14
 
+before_install:
+  - gem install bundler:2.4.22
+  - bundle install
+
 script:
 - set -e
 - "$TRAVIS_BUILD_DIR/travis/install_gcloud.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - NODE_VERSION=v14
 
+before_install:
+- gem install bundler:2.3.9
+
 script:
 - set -e
 - "$TRAVIS_BUILD_DIR/travis/install_gcloud.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 dist: focal
 language: ruby
+rvm:
+- 2.7
 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - NODE_VERSION=v14
-
-before_install:
-  - gem install bundler:2.4.22
-  - bundle install
 
 script:
 - set -e

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt install -y git ruby-dev gcc g++ make libgmp-dev build-essential \
 WORKDIR /home/website
 COPY Gemfile .
 COPY Gemfile.lock .
-RUN gem install bundler
+RUN gem install bundler:2.4.22
 RUN bundle install
 RUN gem cleanup
 

--- a/_tests/travis-checks
+++ b/_tests/travis-checks
@@ -7,7 +7,7 @@ set -e
 
 # Github Pages needs the basejs field to be "src/boot.js" in order for the site
 # to use the source js, but when we deploy to production, we should set this
-# field to one concatenated & minified js file to use on the site.  This 
+# field to one concatenated & minified js file to use on the site.  This
 # command replaces "src/boot.js" with "app.js".
 sed -e '/^basejs/s/\src\/boot\.js/app\.js/' _config.yml > _config-deploy.yml
 
@@ -20,6 +20,8 @@ htmlproofer_args_extra=""
 if [ "$1" = "--quick" ]; then
   htmlproofer_args_extra="--disable-external"
 fi
+
+export PATH=$PATH:$(ruby -e 'puts Gem.user_dir')/bin
 
 # Run HTMLProofer
 bundle exec jekyll build --config _config-deploy.yml

--- a/_tests/travis-checks
+++ b/_tests/travis-checks
@@ -21,8 +21,6 @@ if [ "$1" = "--quick" ]; then
   htmlproofer_args_extra="--disable-external"
 fi
 
-export PATH=$PATH:$(ruby -e 'puts Gem.user_dir')/bin
-
 # Run HTMLProofer
 bundle exec jekyll build --config _config-deploy.yml
 #bundle exec htmlproofer ./_site --only-4xx --file-ignore "/ndt/" "$htmlproofer_args_extra"


### PR DESCRIPTION
Recent builds are failing due to incompatible versions of ruby and the latest bundler. This change pins the bundler version to a compatible one until we can update the build environment and other dependencies.

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment true`, and stop using this flag
Fetching gem metadata from https://rubygems.org/.........
bundler-2.5.0 requires ruby version >= 3.0.0, which is incompatible with the
current version, 2.7.6
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/776)
<!-- Reviewable:end -->
