### PR TITLE
changing gcs to archival data and adding aua

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -11,9 +11,9 @@ breadcrumb: data
 
 Measurement data from many experiments hosted on M-Lab are processed via the ETL pipeline and published in two forms:
 
-* Google Cloud Storage
+* Archival Data
   * M-Lab publishes raw output from many measurement tests on Google Cloud Storage as file archives.
-  * See [M-Lab Google Cloud Storage documentation]({{ site.baseurl }}/data/docs/gcs) for more information.
+  * See [M-Lab Archival Data documentation]({{ site.baseurl }}/data/docs/archival-data) for more information.
 * Google BigQuery
   * M-Lab parses data for a subset of tests and publishes the data on BigQuery so that users can run SQL queries on the data.
   * See [M-Lab BigQuery QuickStart]({{ site.baseurl }}/data/docs/bq/quickstart) for more information.

--- a/_pages/archival.md
+++ b/_pages/archival.md
@@ -1,15 +1,23 @@
 ---
 layout: page
-title: Google Cloud Storage
-permalink: /data/docs/gcs/
+title: Archival Data
+permalink: /data/docs/archival-data/
 breadcrumb: data
 ---
 
-# Google Cloud Storage
-
+# Archival Data
 M-Lab publishes all data it collects in raw form as archives on Google Cloud Storage (GCS) at the following location:
 
 [https://console.developers.google.com/storage/browser/archive-measurement-lab/](https://console.developers.google.com/storage/browser/archive-measurement-lab/){:target="_blank"}
+
+## Acceptable Use Policy
+
+Access to the M-Lab raw data archives requires accepting the [Acceptable Use Agreement](https://docs.google.com/forms/d/e/1FAIpQLSfDGsEqfE3Lh3qtRSMy621O_bzBMZtnrw5sDgR42tGWpymJ2w/viewform). Accepting this agreement helps the M-Lab team ensure responsible use of our data resources and better understand data usage needs and patterns. If you have any questions or need support accessing the data, contact M-Lab for support: [support@measurementlab.net](mailto:support@measurementlab.net).
+
+User Responsibilities:
+
+* Authenticated access: Your email address is required to access M-Lab's data, and usage will be monitored by the M-Lab team.
+* Responsible Resource Use: M-Lab has been collecting large amounts of data since 2008. Please exercise caution when using the raw data by refraining from executing large downloads or attempting to download the entire M-Lab public archive. Such actions can put excessive strain on resources and impact accessibility for others. M-Lab monitors usage and may remove access without warning if it is excessive.
 
 ## File Layout
 


### PR DESCRIPTION
Once Travis finishes:
http://website.mlab-sandbox.measurementlab.net/data/docs/archival-data/

FYI, once accepted, AUA form should be updated to link to policy at www.measurementlab.net/data/docs/archival-data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/791)
<!-- Reviewable:end -->
