### PR TITLE
Replaces old Analytics tag with new GA4 tag

### DIFF
--- a/_includes/ga.js
+++ b/_includes/ga.js
@@ -1,7 +1,10 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-GPGKR8WBC6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', 'UA-56251309-1', 'auto');
-ga('send', 'pageview');
+  gtag('config', 'G-GPGKR8WBC6');
+</script>
+


### PR DESCRIPTION
Universal Analytics (UA) is now retired, replaced by Google Analytics 4 (GA4). This commit replaces the old UA tag with the new GA4 tag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/804)
<!-- Reviewable:end -->
