### PR TITLE
Fixe Analytics GA4 tag inclusion for measurementlab.net

### DIFF
--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -7,6 +7,10 @@
     }
 </style>
 <div id="cookie-notice"><span>We would like to use third party cookies and scripts to improve the functionality of this website.</span><a id="cookie-notice-accept" class="btn btn-primary btn-sm">Approve</a><a href="{{ site.baseurl }}/policies/cookies-notice/" class="btn btn-primary btn-sm">More info</a></div>
+
+<!-- See related Analytics code in the include of ga.js in <script> tag below -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-GPGKR8WBC6"></script>
+
 <script>
     function createCookie(name,value,days) {
         var expires = "";

--- a/_includes/ga.js
+++ b/_includes/ga.js
@@ -1,10 +1,5 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-GPGKR8WBC6"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-GPGKR8WBC6');
-</script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-GPGKR8WBC6');
 


### PR DESCRIPTION
The way I had done it previously was resulting in nested <script> tags, which was breakting things. This commit splits out the loading of gtag/js into its own script tag, and reduces ga.js to only javascript.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/805)
<!-- Reviewable:end -->
