### PR TITLE
Updates links to Mobiperf archival data in GCS

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -80,7 +80,7 @@ There is typically at least a 24-hour delay between data collection and data pub
   * MobiPerf is an open source application for measuring network performance on mobile platforms.
   * MobiPerf data is not processed by the M-Lab ETL Pipeline.
   * More information is available on the [MobiPerf website](http://www.mobiperf.com/){:target="_blank"}
-  * [MobiPerf Raw Data](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
+  * [MobiPerf Raw Data](https://console.cloud.google.com/storage/browser/archive-measurement-lab/mobiperf){:target="_blank"}
 * [NPAD]({{site.baseurl}}/tests/npad)
   * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance.
   * NPAD data is processed by the M-Lab ETL Pipeline.

--- a/_pages/tests/mobiperf.md
+++ b/_pages/tests/mobiperf.md
@@ -11,7 +11,7 @@ MobiPerf is an open source application for measuring network performance on mobi
 
 Please cite this data set as follows: **The M-Lab MobiPerf Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/mobiperf**
 
-**Data** collected by MobiPerf is available in raw format at [https://console.cloud.google.com/storage/browser/openmobiledata_public](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}.
+**Data** collected by MobiPerf is available in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/mobiperf](https://console.cloud.google.com/storage/browser/archive-measurement-lab/mobiperf){:target="_blank"}.
 
 **Source code** is available at [https://github.com/Mobiperf/MobiPerf](https://github.com/Mobiperf/MobiPerf){:target="_blank"}.
 


### PR DESCRIPTION
It used to be in some bucket that we didn't manage, and the links were broken. I worked with Dave Choffnes to get at the data, but a random user found a way to download all the data and shared it with me. I downloaded the data and uploaded it to archive-measurement-lab/mobiperf.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/816)
<!-- Reviewable:end -->
