### PR TITLE
Update contribute/ page + add host-managed documentation

### DIFF
--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -75,9 +75,9 @@ To contribute servers:
 * Complete the [Infrastructure Contribution
   Form](<https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog>).
 * M-Lab will review the submission and contact applicants if approved.  Under some
-* circumstances we may suggest drafting a Memorandum of Understanding (MOU), for
-* example if you contribute more than 10 servers or are exceptional in some
-* other way.
+  circumstances we may suggest drafting a Memorandum of Understanding (MOU), for
+  example if you contribute more than 10 servers or are exceptional in some
+  other way.
 
 M-Lab will provide successful applicants with an API key and other information
 necessary to build and configure measurement servers.

--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -73,7 +73,7 @@ To contribute servers:
   [Privacy Policy](https://www.measurementlab.net/privacy/), and the technical
   and operational requirements in the [host-managed documentation](https://www.measurementlab.net/contribute/host-managed/).
 * Complete the [Infrastructure Contribution
-* Form](<https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog>).
+  Form](<https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog>).
 * M-Lab will review the submission and contact applicants if approved.  Under some
 * circumstances we may suggest drafting a Memorandum of Understanding (MOU), for
 * example if you contribute more than 10 servers or are exceptional in some

--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -69,7 +69,9 @@ second pilot phase.
 
 To contribute servers:
 
-* Review M-Lab's [Acceptable Use Policy](https://www.measurementlab.net/aup/), [Privacy Policy](https://www.measurementlab.net/privacy/), and the technical and operational requirements at the top of [Setting up a host-managed server](https://www.measurementlab.net/host-managed).
+* Review M-Lab's [Acceptable Use Policy](https://www.measurementlab.net/aup/),
+  [Privacy Policy](https://www.measurementlab.net/privacy/), and the technical
+  and operational requirements at the top of [host-managed](https://www.measurementlab.net/contribute/host-managed/).
 * Complete the [registration form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog). M-Lab will review and contact applicants if approved.
 * Under some circumstances we may suggest drafting a Memorandum of Understanding (MOU), for example if you contribute more than 10 servers or are exceptional in some other way.
 

--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -120,7 +120,7 @@ interested in piloting new server specifications. Please contact us at
 
 ### Interested?
 
-Please fill out our online [Infrastructure Ccontribution
+Please fill out our online [Infrastructure Contribution
 Form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog)
 and feel free to reach out to <hello@measurementlab.net>.
 

--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -10,119 +10,135 @@ breadcrumb: contribute
 {:toc}
 
 # Supporting or Contributing to M-Lab
-{:.no_toc}
 
-M-Lab welcomes the participation of individuals and researchers, as well as companies, organizations, and other institutions, that would like to help expand the platform and ensure its growth and success.
+M-Lab welcomes the participation of individuals researchers and ISPs, as well as
+companies, organizations, and other institutions that would like to help expand
+the platform and ensure its growth and success.
+
+Note that all M-Lab usage and contributions are subject to M-Lab’s [Acceptable
+Use Policy](https://www.measurementlab.net/aup/) and [Privacy
+Policy](https://www.measurementlab.net/privacy/). For any contribution of
+significant resources, it might be appropriate to draft a Memorandum of
+Understanding.
 
 ## Develop a Test
 
-Researchers developing and maintaining open source network measurement tests may apply to host a new test on M-Lab. If your project fits within M-Lab's guidelines and principles, we invite you to [email us about M-Lab hosting](mailto:suppport@measurementlab.net).
+Researchers developing and maintaining open source network measurement tests may
+apply to host a new test on M-Lab. If your project fits within M-Lab’s
+guidelines and principles, we invite you to email us about M-Lab hosting.
 
-Please review the documents below before applying:
+Please review these documents below before contacting us:
 
-* [M-Lab Conceptual & Technical Scope & Related Policies]({{ site.baseurl }}/mlab-scope/)
-* [M-Lab Memorandum of Understanding for Experiment Developers]({{ site.baseurl }}/experimenter-mou/)
-* [M-Lab Experiment Developer Responsibilities, Requirements, and Guidelines]({{ site.baseurl }}/experimenter-requirements-guidelines/)
+* [M-Lab Conceptual & Technical Scope & Related Policies](https://www.measurementlab.net/mlab-scope/)
+* [M-Lab Experiment Developer Responsibilities, Requirements, and Guidelines](https://www.measurementlab.net/experimenter-requirements-guidelines/)
 
 ## Use an M-Lab Test in Your Website or Application
 
-M-Lab's open source tests can be added to your website, mobile application, or other software, providing a service to your users and allowing M-Lab to reach more people and generate more data. If you are considering building an M-Lab test into your website or application, you should be familiar with M-Lab's [Privacy]({{ site.basurl }}/privacy) and [Acceptable Use]({{ site.baseurl }}/aup) policies.
+M-Lab’s open source tests can be added to your website, mobile application, or
+other software, providing a service to your users and allowing M-Lab to reach
+more people and generate more data.  The Network Diagnostic Tool (NDT) has been
+used by a number of third party websites and application developers, including
+Google Search, Speedup America, Fing, and several others.
 
-You can find out more information:
+If you are considering building an M-Lab test into your website or application,
+you should be familiar with M-Lab’s
+[Privacy](https://www.measurementlab.net/privacy) and [Acceptable
+Use](https://www.measurementlab.net/aup) policies.
 
-* In our [Developers Guide]({{ site.baseurl }}/develop).
-* In our support answer: [How can I add an M-Lab test to my website, mobile app, or other software?](https://support.measurementlab.net/help/en-us/5-supporting-or-contributing-to-m-lab/24-how-can-i-add-an-m-lab-test-to-my-website-app-or-other-software), in our [data documentation]({{ site.baseurl }}/data/docs)
+You can find out more information in our [Developers
+Guide](https://www.measurementlab.net/develop) and [data
+documentation](https://www.measurementlab.net/data/docs)
 
 ## Host or Sponsor an M-Lab Measurement Site
 
-In 2024, joining the M-Lab platform will be easier than ever with our new flexible options for contributing infrastructure. This following information provides an overview of the options for supporting the platform, increasing resilience, diversity, and reach of the platform in service of M-Lab’s mission.
+It's easier than ever to contribute to Measurement Lab’s platform. The process
+is almost entirely automated, allowing any reasonably modern, high-performance,
+and well-connected physical or virtual server to be added to M-Lab's fleet. This
+will increase the platform's resilience, diversity, and reach, supporting
+M-Lab’s mission.
 
-All contributions are considered tax-deductible donations to Code for Science & Society, M-Lab’s nonprofit fiscal sponsor. To learn more, contact us at [hello@measurementlab.net](mailto:hello@measurementlab.net) and if you are interested in contributing, please fill out our [Infrastructure Contribution Form](https://docs.google.com/forms/d/e/1FAIpQLSe1wXKfQ0VIt_hZFatCwCaoOeeDpRv3JZDM_eAmIaksMuwB4g/viewform?usp=sf_link).
+All contributions are considered tax-deductible donations to Code for Science &
+Society, M-Lab’s nonprofit fiscal sponsor. To learn more, contact us at
+<hello@measurementlab.net>.
+
+### Host-Managed Deployment
+
+This is the best way for small to medium sized ISPs or other organizations to
+contribute M-Lab servers.  We are now accepting new host organizations in a
+second pilot phase.
+
+To contribute servers:
+
+* Review M-Lab's [Acceptable Use Policy](https://www.measurementlab.net/aup/), [Privacy Policy](https://www.measurementlab.net/privacy/), and the technical and operational requirements at the top of [Setting up a host-managed server](https://www.measurementlab.net/host-managed).
+* Complete the [registration form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog). M-Lab will review and contact applicants if approved.
+* Under some circumstances we may suggest drafting a Memorandum of Understanding (MOU), for example if you contribute more than 10 servers or are exceptional in some other way.
+
+M-Lab will provide successful applicants with an API key and other information
+necessary to build and configure measurement servers.
+
+### Jointly Managed Deployment
+
+We are developing a new deployment model suitable for organizations that can
+automatically manage a fleet of physical or virtual servers.
+
+If this is a possibility for your organization, please get in touch with us at
+[hello@measurementlab.net](mailto:hello@measurementlab.net). We want to ensure
+our new deployment model is compatible with existing fleet orchestration
+technologies and would love to hear from you.
 
 ### Cloud Credits for Virtual Servers
 
-The easiest way to donate infrastructure to M-Lab is by donating resources for cloud credits from providers such as Google Cloud, Amazon Web Services, Azure, Equinix, Linode, IBM and others. M-Lab can host 1 site for $30,000 to $360,000 credits annually, where total price depends on user demand, service availability, and market rates. M-Lab services are highly configurable and can work within any budget in any market at lower availability.
+The easiest way to donate infrastructure to M-Lab is by providing cloud credits
+from major providers such as **Google Cloud**, **Amazon Web Services**,
+**Azure**, **Equinix**, **Linode**, **IBM**, etc.
 
-This option is best for contributors who
+On average, our fleet's egress load (typically the most expensive cost) is about
+**100 Mb/s** per server.  However, our busiest servers can average almost **3
+Gb/s**. We can steer measurement traffic to limit the load on any individual
+server, allowing us to tune traffic to fit your budget.
 
-* Currently offer Cloud services and want their infrastructure represented in reports using M-Lab data
-* Only have access to virtual networks and resources
-* Want M-Lab to manage the virtual resources on your behalf
+This option is ideal for contributors who offer large-scale cloud services, but
+are not interested in co-managing their contribution to our fleet.
 
-### Full Hardware Deployment managed by M-Lab
+### Hardware Deployment Managed by M-Lab
 
-To contribute resources to be managed and deployed by M-Lab using our full deployment model, the following will be required:
+The current M-Lab physical fleet consists of bare metal servers with Dell’s
+iDRAC remote console and software fully managed by M-Lab.  A minimal deployment
+would consist of one server with statically assigned, globally routed /28 or /29
+IPv4 prefix and one /64 IPv6 prefix.  The legacy full deployment (4 servers and
+a switch) is no longer necessary.
 
-* A /26 IPv4 prefix and /64 IPv6 prefix, both globally routed, and statically assigned to M-Lab equipment
-* Standard hardware[^1] including:
-  * 4x Dell PowerEdges server with iDRAC
-  * 1x Juniper switch with 10Gbit/s uplink
-* 5U rackspace and power
-* A 10Gbit/s uplink to the Internet
-* Remote support in coordination with M-Lab for installation and periodic maintenance
-
-This option is best for contributors who:
-
-* Currently offer rack space and power
-* Have network capacity to support high user demand
-* Can sponsor all costs associated with a full site deployment managed by M-Lab on your behalf
-* Can provide network locations that measure paths relevant for user experience accessing content & services on the Internet
-
-### Minimal Hardware Deployment managed by M-Lab
-
-To contribute resources to be managed and deployed by M-Lab using our minimal deployment model, the following will be required:
-
-* A /28 or /29 IPv4 prefix and /64 IPv6 prefix, both globally routed, and statically assigned to M-Lab equipment
-* Standard hardware* including:
-  * 1x Dell PowerEdge server with iDRAC
-* 1U rackspace and power
-* A 10Gbit/s uplink to the Internet
-* Remote support in coordination with M-Lab for installation and periodic maintenance, including secure access to the iDRAC
-
-This option is best for contributors who:
-
-* Can sponsor all costs associated with a minimal site deployment managed by M-Lab on your behalf
-* Can provide network locations that measure paths relevant for user experience accessing content & services on the Internet
-* Are not able to support a full scale deployment
-
-We are open to Trusted Testers for Minimal Deployments in 2024 Q2 and plan to make this option generally available by 2024 Q3.
-
-\* New hardware models may need to be qualified by M-Lab before we can accept them as part of the platform, but additional resources could be required to support the qualification process.
-
-### Host Managed Deployment
-
-Host managed deployments are managed and deployed by the contributor and can be physical or virtual. All data is collected and archived to the M-Lab data pipeline.
-
-To run a host managed M-Lab server, the following is needed:
-
-* Registration with M-Lab for a host managed deployment
-* An IPv4/32 address and IPv6/128 address, both globally routed, and statically assigned to the contributed server
-* A physical or virtual server with at least 4GB RAM & 4 CPUs (Intel class)
-* At least 1Gbit/s uplink to the Internet
-
-This option is best for contributors who:
-
-* Currently offer or have easy access to a single physical or virtual server
-* Already maintain an Network Diagnostic Tool, Measurement Swiss Army Knife, or Reverse Traceroute server and want to contribute data to M-Lab’s public dataset or
-* Already maintain other speed test servers in their network or
-* Are not able to to provide the resources necessary for M-Lab managed servers but are still interested in contributing infrastructure
-
-We are open to Trusted Testers for Host-Managed deployment in 2024 Q3 and plan to make this option generally available by 2024 Q4.
+If you are interested in contributing hardware to the M-Lab platform we would be
+interested in piloting new server specifications. Please contact us at
+[hello@measurementlab.net](mailto:hello@measurementlab.net).
 
 ### Interested?
 
-Please fill out our [Infrastructure Contribution Form](https://docs.google.com/forms/d/e/1FAIpQLSe1wXKfQ0VIt_hZFatCwCaoOeeDpRv3JZDM_eAmIaksMuwB4g/viewform?usp=sf_link) and feel free to reach out to [hello@measurementlab.net](mailto:hello@measurementlab.net).
+Please fill out our online [infrastructure contribution
+form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog)
+and feel free to reach out to <hello@measurementlab.net>.
 
-## Analyze and Visualize M-Lab Data
+## **Analyze and Visualize M-Lab Data**
 
-M-Lab welcomes researchers who want to dig into the M-Lab data, providing documentation and best-effort email support. If you are interested in working with M-Lab data in your research, please review our [data documentation]({{ site.baseurl }}/data) to help get you started, and [contact us](mailto:support@measurementlab.net) with any questions. We also suggest that you join our [public mailing list](https://groups.google.com/a/measurementlab.net/forum/?fromgroups#!forum/discuss){:target="_blank"} for news and announcements.
+M-Lab welcomes researchers who want to dig into the M-Lab data, providing
+documentation and best-effort email support. If you are interested in working
+with M-Lab data in your research, please review our [data
+documentation](https://www.measurementlab.net/data) to help get you started, and
+contact us with any questions. We also suggest that you join our [public mailing
+list](https://groups.google.com/a/measurementlab.net/forum/?fromgroups#!forum/discuss)
+for news and announcements.  If you have experience in web or application
+development, data analysis, or visualization, you may be interested in working
+with M-Lab’s tests, data, and analysis tools, all of which are open source and
+openly licensed.
 
-If you have experience in web or application development, data analysis, or visualization, you may be interested in working with M-Lab's tests, data, and analysis tools, all of which are open source and openly licensed.
+* [M-Lab’s conceptual and technical scope and policies](https://www.measurementlab.net/publications/mlab-founding-vision.pdf)
+* [M-Lab’s Roles & Responsibilities for new researchers](https://www.measurementlab.net/publications/mlab-roles-responsibilities.pdf)
+* [M-Lab’s requirements and procedures for accepting new tools](https://www.measurementlab.net/publications/mlab-procedures-new-tools.pdf)
 
-* [M-Lab's conceptual and technical scope and policies]({{ site.baseurl }}/publications/mlab-founding-vision.pdf)
-* [M-Lab's Roles &amp; Responsibilities for new researchers]({{ site.baseurl }}/publications/mlab-roles-responsibilities.pdf)
-* [M-Lab's requirements and procedures for accepting new tools]({{ site.baseurl }}/publications/mlab-procedures-new-tools.pdf)
+## **Donate to M-Lab**
 
-## Donate to M-Lab
-
-M-Lab welcomes the direct financial contributions of organizations that find our work beneficial. If your organization is interested in supporting the M-Lab platform, please review our [sponsorship offerings]({{ site.baseurl }}/documents/mlab-sponsorship.pdf) and [contact us](mailto:hello@measurementlab.net).
+M-Lab welcomes the direct financial contributions of organizations that find our
+work beneficial. If your organization is interested in supporting the M-Lab
+platform, please review our [sponsorship
+offerings](https://www.measurementlab.net/documents/mlab-sponsorship.pdf) and
+contact us.

--- a/_pages/09-contribute.md
+++ b/_pages/09-contribute.md
@@ -47,7 +47,7 @@ Use](https://www.measurementlab.net/aup) policies.
 
 You can find out more information in our [Developers
 Guide](https://www.measurementlab.net/develop) and [data
-documentation](https://www.measurementlab.net/data/docs)
+documentation](https://www.measurementlab.net/data/docs).
 
 ## Host or Sponsor an M-Lab Measurement Site
 
@@ -64,28 +64,32 @@ Society, M-Lab’s nonprofit fiscal sponsor. To learn more, contact us at
 ### Host-Managed Deployment
 
 This is the best way for small to medium sized ISPs or other organizations to
-contribute M-Lab servers.  We are now accepting new host organizations in a
+contribute M-Lab servers. We are now accepting new host organizations in a
 second pilot phase.
 
 To contribute servers:
 
 * Review M-Lab's [Acceptable Use Policy](https://www.measurementlab.net/aup/),
   [Privacy Policy](https://www.measurementlab.net/privacy/), and the technical
-  and operational requirements at the top of [host-managed](https://www.measurementlab.net/contribute/host-managed/).
-* Complete the [registration form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog). M-Lab will review and contact applicants if approved.
-* Under some circumstances we may suggest drafting a Memorandum of Understanding (MOU), for example if you contribute more than 10 servers or are exceptional in some other way.
+  and operational requirements in the [host-managed documentation](https://www.measurementlab.net/contribute/host-managed/).
+* Complete the [Infrastructure Contribution
+* Form](<https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog>).
+* M-Lab will review the submission and contact applicants if approved.  Under some
+* circumstances we may suggest drafting a Memorandum of Understanding (MOU), for
+* example if you contribute more than 10 servers or are exceptional in some
+* other way.
 
 M-Lab will provide successful applicants with an API key and other information
 necessary to build and configure measurement servers.
 
 ### Jointly Managed Deployment
 
-We are developing a new deployment model suitable for organizations that can
-automatically manage a fleet of physical or virtual servers.
+We are investigating a new deployment model where management of the machines is
+split between an organization and M-Lab in some way.
 
 If this is a possibility for your organization, please get in touch with us at
 [hello@measurementlab.net](mailto:hello@measurementlab.net). We want to ensure
-our new deployment model is compatible with existing fleet orchestration
+any new deployment model is compatible with existing fleet orchestration
 technologies and would love to hear from you.
 
 ### Cloud Credits for Virtual Servers
@@ -116,8 +120,8 @@ interested in piloting new server specifications. Please contact us at
 
 ### Interested?
 
-Please fill out our online [infrastructure contribution
-form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog)
+Please fill out our online [Infrastructure Ccontribution
+Form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog)
 and feel free to reach out to <hello@measurementlab.net>.
 
 ## **Analyze and Visualize M-Lab Data**

--- a/_pages/host-managed-documentation.md
+++ b/_pages/host-managed-documentation.md
@@ -1,9 +1,8 @@
 ---
 layout: page
-permalink: /host-managed/
 title: "Host-Managed Documentation"
-menu-item: false
-breadcrumb: host-managed
+permalink: /contribute/host-managed/
+breadcrumb: contribute
 ---
 
 # Setting up a host-managed server

--- a/_pages/host-managed-documentation.md
+++ b/_pages/host-managed-documentation.md
@@ -1,0 +1,179 @@
+---
+layout: page
+permalink: /host-managed/
+title: "Host-Managed Documentation"
+menu-item: false
+breadcrumb: host-managed
+---
+
+# Setting up a host-managed server
+
+## Register with M-Lab
+
+The first step in becoming an M-Lab site host is to complete the [Infrastructure Contribution Form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform?usp=dialog), which includes agreeing to [M-Lab’s Acceptable Use Policy](https://www.measurementlab.net/aup/), [Privacy Policy](https://www.measurementlab.net/privacy/), and the Technical Requirements listed below.
+
+M-Lab will review your submission and confirm that you qualify to become an M-Lab site host.  Under some circumstances we may suggest drafting a Memorandum of Understanding (MoU) if, for example, you contribute more than 10 servers or are exceptional in some other way.   Once you qualify, M-Lab will provide you with an API key and other information necessary to build and configure measurement servers.
+
+If a host-managed deployment does not appear to be the best way for your organization to contribute to M-Lab, consider [other options](https://www.measurementlab.net/contribute/).
+
+## Serving Requirements
+
+In order to maintain the highest data quality we require all measurement servers
+to:
+
+- Have at least four 2 GHz CPUs with 4GB RAM (Intel class).  More is better, especially at a busy site.
+- They can be either physical or virtual machines but should not have significant shared workloads on the underlying hardware.
+- Must run some reasonably up-to-date version of Linux that supports the tcp_bbr kernel module and Docker.
+  - At this time we are not aware of any restrictions on distro
+  - M-Lab has tested with Ubuntu and Debian.
+- One static IPv4 and one static IPv6 address.  The IPv6 address can be waived in  rare regions where IPv6 is not adequately deployed.
+- A 10 GB/s uplink, unless the local infrastructure does not generally support it, in which case the uplink should be at least twice as fast as readily available consumer grade connections or 1 Gb/s, whichever is faster.  (e.g. if there are 1 Gb/s consumer grade connections, the server should have at least 2 Gb/s.)
+- The server can be behind a firewall, but must have the following ports open:
+  - 80 (unecrypted NDT tests)
+  - 443 (encrypted NDT tests)
+  - 9990-9999 (monitoring)
+
+## Operational Requirements
+
+In order to assure the ongoing data quality we require all host organizations
+to:
+
+- Keep their contact information at M-Lab up-to-date.
+- Monitor email from <host-managed@measurementlab.net>, the host management list.
+- Respond to email requests from the M-Lab team.
+- Keep the operating system up-to-date by applying system updates as needed.
+- Keep M-Lab software up-to-date by reinstalling it as requested.  (We are planning to further automate this process).
+- Provide their own server health monitors and alerts.
+- Monitor traffic volumes and server loads, and adjust the serving probability as necessary.
+
+## Deploying the software
+
+The first step is cloning this repository to the machine. It doesn't matter where on the machine the repository is located:
+
+```shell
+git clone https://github.com/m-lab/autonode
+cd autonode
+```
+
+The software services run in Docker containers, which are deployed using Docker
+Compose. This, of course, implies that the machine must have [Docker
+installed](https://docs.docker.com/engine/install/). The root of the repository contains
+[the Docker Compose configuration
+file](https://github.com/m-lab/autonode/blob/main/docker-compose.yml), which is named *docker-compose.yml*.
+
+The Docker Compose file should *not* be modified. Any required, user-configurable
+settings should be set in [the environment variable
+file](https://github.com/m-lab/autonode/blob/main/env), named simply *env*. The *env* file is
+fairly well commented, but here is an outline of the variables and what sort of
+values they should have:
+
+- **ORGANIZATION**: the organization name assigned to you by M-Lab after you register.
+- **API_KEY**: the API key that M-Lab provides you after you register.
+- **IATA**: the 3-character [IATA
+  code](https://www.iata.org/en/publications/directories/code-search/) of the
+  nearest airport. If the nearest airport doesn't have an IATA code, then find
+  the nearest one that does. M-Lab will work with you on the proper value for
+  this variable.
+- **PROBABILITY**: this is the probability that M-Lab's load balancing service
+  ([Locate Service](https://github.com/m-lab/locate)) will send a test to your
+  server. The M-Lab platform gets many millions of tests per day. Depending on
+  where your server is located, its resources, and the speed of the machine's
+  uplink, the test volume could possible overwhelm the machine and/or your
+  network. You can modify this to suit your needs, either increasing or
+  decreasing the traffic load as necessary.   This is the preffered mechanism for regulating server load.
+- **INTERFACE_NAME**: the NDT server needs to know the name of the primary network
+  interface on the machine (e.g., eth0, enp114s0, etc.)
+- **UPLINK**: the speed of the machine's connection to the Internet.
+- **INTERFACE_MAXRATE**: when the bitrate on the interface exceeds this value the NDT server will start refusing connections.  INTERFACE_MAXRATE is intended to limit the load during flash crowds to prevent the server from saturating its own uplink which would result in inaccurate measurements of other portions of the path.  In the absence of other nearby network bottlenecks the recommended value is 70% of the uplink capacity.   You may set it lower, for example to limit serving costs, but if you do so, please adjust the probability down to avoid sending unnecessary errors to users.
+- **IPV4**: the public IPv4 address of the primary network interface.
+- **IPV6**: the public IPv6 address of the primary network interface.
+- **TYPE**: the type of the machine, either "physical" or "virtual".
+
+Once you have filled in values for all of the environment variable is the env
+file, these steps should be performed:
+
+```shell
+# Recommended: add "tcp_bbr" to /etc/modules so that it gets loaded on each reboot.
+sudo modprobe tcp_bbr
+
+# Verify the environment and credentials are working, then manually shutdown with ctrl-C.
+docker compose --profile check-config --env-file env up
+
+# Start the ndt service in the background. This will restart automatically on reboot.
+docker compose --profile ndt --env-file env up -d
+```
+
+If there were no errors, then your machine should start receiving production
+M-Lab tests within less than a minute.
+
+## Test volume and probability
+
+It is important to note that your M-Lab node will receive traffic from many networks, not just your own. The M-Lab [Locate Service](https://github.com/m-lab/locate), which all clients query to get a list of servers to test against, will generally direct clients to the geographically closest server. This is true for your own users, as well as users on other networks. If your server is the only M-Lab server for a large region, depending on various factors it may attract a significant amount of test traffic.
+
+The *PROBABILITY* environment variable is designed to allow you to modify how often the Locate Service directs traffic to your server. This can help you reduce the load on your server and network. However, it is **important to note** that the probability will apply to your own network users as well.
+M-Lab explicitly does not use network topology or measurements (e.g. RTT) to select servers.
+
+Once you have modified the value of the *PROBABILITY* variable in the env file (or any other parameter), you will need to stop and restart all Docker containers:
+
+```shell
+docker compose --profile ndt --env-file env down
+docker compose --profile ndt --env-file env up -d
+```
+
+## Host names
+
+The server will automatically receive a public DNS name, which is generated by
+the Autojoin API. The name will follow this pattern:
+
+```shell
+ndt-<IATA><ASN>-<IPv4 HEX>.<ORGANIZATION>.autojoin.measurement-lab.org
+```
+
+- IATA: the 3-letter IATA code specified in the Docker Compose file
+- ASN: the AS number of the IPv4 address of the machine (automatically
+  determined using [CAIDA Routeviews
+  data](https://www.caida.org/catalog/datasets/routeviews-prefix2as/))
+- IPV4 HEX: A hexadecimal representation of the IPv4 address of the machine
+- ORGANIZATION: the name of your organization
+
+For example:
+
+```shell
+ndt-oma396982-22486078.mlab.autojoin.measurement-lab.org
+```
+
+## Monitoring and Server Availability
+
+M-Lab will collect metrics from the various services that are running on your machine, but will **not** alert or notify you when a problem is detected. You should set up monitoring and alerting of your own, possibly collecting some or all of the same metrics that M-Lab collects. The following [Prometheus](https://github.com/prometheus/prometheus) metrics endpoints are exposed:
+
+- [ndt-server](https://github.com/m-lab/ndt-server): http://<hostname/ip>:9990/metrics
+- [jostler](https://github.com/m-lab/jostler): http://<hostname/ip>:9991/metrics
+- [uuid-annotator](https://github.com/m-lab/uuid-annotator): http://<hostname/ip>:9992/metrics
+- [heartbeat](https://github.com/m-lab/locate/tree/main/cmd/heartbeat): http://<hostname/ip>:9993/metrics
+- [traceroute-caller](https://github.com/m-lab/traceroute-caller): http://<hostname/ip>:9994/metrics
+- [node_exporter](https://github.com/prometheus/node_exporter): http://<hostname/ip>:9995/metrics
+
+Of those metrics, you are probably only interested in those from ndt-server and node_exporter. The main metric from ndt-server that you may be interested in is *ndt7_client_test_results_total*, which allows you to calculate test rates on your server using [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/). For example, the following PromQL query would tell you how many tests your machine is serving per minute:
+
+```shell
+60 * sum(rate(ndt7_client_test_results_total{result!="error-without-rate"}[5m]))
+```
+
+node_exporter metrics allow you to monitor resource usage on your machine (e.g., CPU, memory, disk, etc.). There a many very good tutorials on the Web about how to set up Prometheus to scrape metrics, and how to visualize those using [Grafana](https://grafana.com/).
+
+## Calibration
+
+M-Lab will monitor server resource consumption and evidence of accuracy problems with the data. We may ask you to make configuration changes or other improvements. If your results are deemed inaccurate we reserve the right to minimize your test volume to protect M-Lab’s overall data quality.
+
+## Autojoin Implementation
+
+![Register & Measure](https://github.com/user-attachments/assets/d122e56a-3bba-42b2-a44a-51a4055eb045)
+
+Once the machine is up and running, these operations will be performed automatically:
+
+1. Register with the [Autojoin API](https://github.com/m-lab/autojoin)
+2. Distribute credentials & metadata to local services
+3. Report node health to the [Locate API](https://github.com/m-lab/locate)
+4. Clients run [NDT tests](https://github.com/m-lab/ndt-server) targeting this node
+5. NDT measurements are archived
+6. NDT measurements are published to BigQuery


### PR DESCRIPTION
This PR updates the contribute/ page in accordance with the [draft change document](https://docs.google.com/document/d/12PaZkBLzD4kufMz0LjXvRDwF5EY-YIElLHPKWFaKlTA/) that @mattmathis created.

Additionally, it moves the host-managed deployment documentation from the autonode repo wiki to a page on the website:

http://website.mlab-sandbox.measurementlab.net/contribute/host-managed/

Also, the links to the Infrastructure Contribution Form will now point to [the new form](https://docs.google.com/forms/d/e/1FAIpQLSejtmZJrW8BPuuhjG4FlGm0fFmN3cW6onvLsCxkd3UnECVd9Q/viewform).

http://website.mlab-sandbox.measurementlab.net/contribute/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/839)
<!-- Reviewable:end -->
