### PR TITLE
fix(css): stop floated grid tiles snagging and leaving whitespace holes

### DIFF
--- a/_sass/components/_grids.scss
+++ b/_sass/components/_grids.scss
@@ -15,6 +15,17 @@
     padding-left: 0px;
   }
 
+  // Tile lists lay out with Bootstrap's floated .col-* classes. Floats snag on
+  // the tallest tile in the previous row, so a group whose descriptions differ
+  // in length leaves whitespace holes in the grid (most visible in "Retired
+  // Tests", which has the widest spread). Flex-wrap breaks rows on count rather
+  // than on cleared height. Scoped to ul.l-grid so .partner-logos is untouched.
+  ul.l-grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
   .grid-group {
     padding-top: 20px;
   }


### PR DESCRIPTION
The /tests/ tile grid relies on Bootstrap’s floated columns, which causes whitespace gaps when tiles have different heights. Making ul.l-grid a flex-wrap container preserves the existing column widths while removing those gaps, without affecting other grid-section lists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/890)
<!-- Reviewable:end -->
